### PR TITLE
0.1.11: Remove redundant logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.1.10"
+version="0.1.11"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -244,8 +244,8 @@ class Session(object):
                 continue
             current_time = await self._get_current_time()
             if current_time > self._close_session_after_time_secs:
-                logging.info(
-                    "Grace period ended for :" f" {self._transport_id}, closing session"
+                logging.debug(
+                    "Grace period ended for %s, closing session", self._transport_id
                 )
                 await self.close(False)
                 return

--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -113,8 +113,8 @@ class Session(object):
 
     async def _on_websocket_unexpected_close(self) -> None:
         """Handle unexpected websocket close."""
-        logging.info(
-            f"Unexpected websocket close from {self._transport_id} to {self._to_id}"
+        logging.debug(
+            "Unexpected websocket close from %s to %s", self._transport_id, self._to_id
         )
         await self._begin_close_session_countdown()
 

--- a/replit_river/transport.py
+++ b/replit_river/transport.py
@@ -139,8 +139,8 @@ class Transport:
                     except FailedSendingMessageException as e:
                         raise e
         if session_to_close:
-            logging.info(
-                f"Closing stale session {session_to_close.advertised_session_id}"
+            logging.debug(
+                "Closing stale session %s", session_to_close.advertised_session_id
             )
             await session_to_close.close(False)
             logging.info(

--- a/replit_river/transport_options.py
+++ b/replit_river/transport_options.py
@@ -13,7 +13,7 @@ class ConnectionRetryOptions(BaseModel):
     max_backoff_ms: float = 32_000
     attempt_budget_capacity: float = 5
     budget_restore_interval_ms: float = 200
-    max_retry: int = 1_000
+    max_retry: int = 10
 
 
 # setup in replit web can be found at


### PR DESCRIPTION
Why
===
We have too many logs in datadog! closing sessions are logged 3 times

What changed
============
down grade some logs to debug

Test plan
=========
Unit + river babel
