### PR TITLE
0.1.13: Simplify websocket management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.1.12"
+version="0.1.13"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/client_session.py
+++ b/replit_river/client_session.py
@@ -38,7 +38,6 @@ class ClientSession(Session):
         output: Channel[Any] = Channel(1)
         self._streams[stream_id] = output
         await self.send_message(
-            ws=self._ws,
             stream_id=stream_id,
             control_flags=STREAM_OPEN_BIT | STREAM_CLOSED_BIT,
             payload=request_serializer(request),
@@ -91,7 +90,6 @@ class ClientSession(Session):
             if init and init_serializer:
                 await self.send_message(
                     stream_id=stream_id,
-                    ws=self._ws,
                     control_flags=STREAM_OPEN_BIT,
                     service_name=service_name,
                     procedure_name=procedure_name,
@@ -107,7 +105,6 @@ class ClientSession(Session):
                     first_message = False
                 await self.send_message(
                     stream_id=stream_id,
-                    ws=self._ws,
                     service_name=service_name,
                     procedure_name=procedure_name,
                     control_flags=control_flags,
@@ -158,7 +155,6 @@ class ClientSession(Session):
         output: Channel[Any] = Channel(MAX_MESSAGE_BUFFER_SIZE)
         self._streams[stream_id] = output
         await self.send_message(
-            ws=self._ws,
             service_name=service_name,
             procedure_name=procedure_name,
             stream_id=stream_id,
@@ -209,7 +205,6 @@ class ClientSession(Session):
         try:
             if init and init_serializer:
                 await self.send_message(
-                    ws=self._ws,
                     service_name=service_name,
                     procedure_name=procedure_name,
                     stream_id=stream_id,
@@ -221,7 +216,6 @@ class ClientSession(Session):
                 request_iter = aiter(request)
                 first = await anext(request_iter)
                 await self.send_message(
-                    ws=self._ws,
                     service_name=service_name,
                     procedure_name=procedure_name,
                     stream_id=stream_id,
@@ -238,7 +232,6 @@ class ClientSession(Session):
                 if item is None:
                     continue
                 await self.send_message(
-                    ws=self._ws,
                     service_name=service_name,
                     procedure_name=procedure_name,
                     stream_id=stream_id,
@@ -275,7 +268,6 @@ class ClientSession(Session):
     ) -> None:
         # close stream
         await self.send_message(
-            ws=self._ws,
             service_name=service_name,
             procedure_name=procedure_name,
             stream_id=stream_id,

--- a/replit_river/websocket_wrapper.py
+++ b/replit_river/websocket_wrapper.py
@@ -1,0 +1,33 @@
+import asyncio
+import enum
+import logging
+
+from websockets import WebSocketCommonProtocol
+
+
+class WsState(enum.Enum):
+    OPEN = 0
+    CLOSING = 1
+    CLOSED = 2
+
+
+class WebsocketWrapper:
+    def __init__(self, ws: WebSocketCommonProtocol) -> None:
+        self.ws = ws
+        self.ws_state = WsState.OPEN
+        self.ws_lock = asyncio.Lock()
+        self.id = ws.id
+
+    async def is_open(self) -> bool:
+        async with self.ws_lock:
+            return self.ws_state == WsState.OPEN
+
+    async def close(self) -> None:
+        async with self.ws_lock:
+            if self.ws_state == WsState.OPEN:
+                self.ws_state = WsState.CLOSING
+                task = asyncio.create_task(self.ws.close())
+                task.add_done_callback(
+                    lambda _: logging.debug("old websocket %s closed.", self.ws.id)
+                )
+                self.ws_state = WsState.CLOSED


### PR DESCRIPTION
Why
===
Websocket management is flaky

What changed
============
We defer websocket lock to a websocket wrapper, and obtain a lock every time before we send a message.

Test plan
=========
River babel