### PR TITLE
0.1.21: river handshake with metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.1.20"
+version="0.1.21"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"


### PR DESCRIPTION
Why
===
Support river schema changes

What changed
============
Added support for adding metadata in the handshake

Test plan
=========
CICD
