### PR TITLE
Fix unable to pass handshake metadata to Client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.1.21"
+version="0.1.22"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -20,6 +20,7 @@ class Client:
         client_id: str,
         server_id: str,
         transport_options: TransportOptions,
+        handshake_metadata: Optional[Any] = None,
     ) -> None:
         self._client_id = client_id
         self._server_id = server_id
@@ -28,6 +29,7 @@ class Client:
             client_id=client_id,
             server_id=server_id,
             transport_options=transport_options,
+            handshake_metadata=handshake_metadata,
         )
 
     async def close(self) -> None:


### PR DESCRIPTION
Why
===

In #17 I didn't realize that ClientTransport is constructed internally in Client, so there's currently no way of passing it to ClientTransport!

derp

What changed
============
Add `handshake_metadata` argument to `Client`


Test plan
=========

Same as #17
