### PR TITLE
Fix the state log for ws

### DIFF
--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -485,7 +485,7 @@ class Session(object):
         logging.info(
             f"{self._transport_id} closing session "
             f"to {self._to_id}, ws: {self._ws_wrapper.id}, "
-            f"current_state : {self._ws_wrapper}"
+            f"current_state : {self._ws_wrapper.ws.state.name}"
         )
         async with self._state_lock:
             if self._state != SessionState.ACTIVE:

--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -485,7 +485,7 @@ class Session(object):
         logging.info(
             f"{self._transport_id} closing session "
             f"to {self._to_id}, ws: {self._ws_wrapper.id}, "
-            f"current_state : {self._ws_wrapper.ws.state.name}"
+            f"current_state : {self._ws_wrapper.ws_state.name}"
         )
         async with self._state_lock:
             if self._state != SessionState.ACTIVE:


### PR DESCRIPTION
Why
===
The log for ws is outputing something not useful
```SERVER closing session to chat-client-5853b5ca-0e45-4ef7-8a7b-cfbfd7d70c3e-20915921-basic, ws: 2157f585-39a2-4906-a09b-c4b2b53436b1, current_state : <replit_river.websocket_wrapper.WebsocketWrapper object at 0x7a4e143a9c90```

What changed
============
Fix it to output the name