### PR TITLE
Add default value to optional handshake request field

### DIFF
--- a/replit_river/rpc.py
+++ b/replit_river/rpc.py
@@ -51,7 +51,7 @@ class ControlMessageHandshakeRequest(BaseModel):
     type: Literal["HANDSHAKE_REQ"] = "HANDSHAKE_REQ"
     protocolVersion: str
     sessionId: str
-    metadata: Optional[Any]
+    metadata: Optional[Any] = None
 
 
 class HandShakeStatus(BaseModel):


### PR DESCRIPTION
Why
===

Before https://github.com/replit/river/pull/131, we used to cast `undefined` fields to `null` over the wire (in msgpack). Pydantic throws if there's an `Optional` field without a default value and not specified in the data dict.

Hopefully this Repl explains what's going on https://replit.com/@replitfaris/pydantic-handshake-missing-optional-metadata#main.py


What changed
============

Set default value for `ControlMessageHandshakeRequest['metadata']`.

I think this fix is better than reverting https://github.com/replit/river/pull/131, it's also a fix forward for existing clients. That said we should think about this a little more deeply, because in python-land we have the same problem where `Optional` fields can end up being `null` over the wire.

Test plan
=========

See repl above.
