### PR TITLE
bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.0"
+version="0.2.1"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"


### PR DESCRIPTION
Why
===

* We need the fixes for the "integer" type to compile the schemas
 
What changed
============

* Bump version number so we can do a release
