### PR TITLE
Fix the enum parsing in python client codegen

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -65,6 +65,9 @@ def encode_type(
         if type.type == "Uint8Array":
             return ("bytes", ())
         if type.type == "number":
+            if type.const is not None:
+                # enums are represented as const number in the schema
+                return ("int", ())
             return ("float", ())
         if type.type == "integer":
             return ("int", ())


### PR DESCRIPTION
Why
===
Enum are represented as const numbers in schema, but python will interpret them as float (they should be int)

What changed
============
Make it int

Test plan
=========
CICD