### PR TITLE
Make `Optional` types truly Optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.2"
+version="0.2.3"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -95,14 +95,21 @@ def encode_type(
                     prop, prefix + name.title(), base_model
                 )
                 chunks.extend(type_chunks)
-                if name not in type.required:
-                    type_name = f"Optional[{type_name}]"
                 if name == "$kind":
-                    current_chunks.append(
-                        f"  kind: {type_name} = Field(..., alias='{name}')"
-                    )
+                    if name not in type.required:
+                        current_chunks.append(
+                            f"  kind: Optional[{type_name}] = "
+                            f"Field(..., alias='{name}', default=None)"
+                        )
+                    else:
+                        current_chunks.append(
+                            f"  kind: {type_name} = Field(..., alias='{name}')"
+                        )
                 else:
-                    current_chunks.append(f"  {name}: {type_name}")
+                    if name not in type.required:
+                        current_chunks.append(f"  {name}: Optional[{type_name}] = None")
+                    else:
+                        current_chunks.append(f"  {name}: {type_name}")
         else:
             current_chunks.append("  pass")
         current_chunks.append("")


### PR DESCRIPTION
Why
===

The codegen currently correctly emits optional data types as `Optional[T]`. That's good, but what was missing was that these should also have a default value of `None`
[[docs](https://docs.pydantic.dev/latest/concepts/fields/)].

What changed
============

This change now makes it such that optional fields are truly optional and have a default value of `None` so that we can always upgrade schemas safely.

Test plan
=========

https://github.com/replit/ai-infra/pull/1309 wouldn't have required the new fields.