### PR TITLE
Support nested object types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.3"
+version="0.2.4"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/codegen/server.py
+++ b/replit_river/codegen/server.py
@@ -183,7 +183,7 @@ def message_encoder(
             value = f"_{field.name}"
         chunks.extend(
             [
-                f"  _{field.name} = getattr(e, '{field.name}', None)",
+                f"  _{field.name} = e.{field.name}",
                 f"  if _{field.name} is not None:",
                 f"    d['{to_camel_case(field.name)}'] = {value}",
             ]
@@ -193,12 +193,12 @@ def message_encoder(
         chunks.append(f"  match e.WhichOneof('{oneof.name}'):")
         for field in oneofs[index]:
             if field.type_name == ".google.protobuf.Timestamp":
-                value = f"getattr(e, '{field.name}', None).ToDatetime()"
+                value = f"e.{field.name}.ToDatetime()"
             elif field.type == descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE:
                 encode_method_name = get_encoder_name(field)
-                value = f"{encode_method_name}(getattr(e, '{field.name}', None))"
+                value = f"{encode_method_name}(e.{field.name})"
             else:
-                value = f"getattr(e, '{field.name}', None)"
+                value = f"e.{field.name}"
             chunks.extend(
                 [
                     f"    case '{field.name}':",


### PR DESCRIPTION
Why
===

We had a problem using `getattr` because it produces the wrong type.

What changed
============

This change now switches that to use the regular proto getter so that mypy doesn't complain.

Test plan
=========

Codegenned the new chat types with this in https://replit.semaphoreci.com/workflows/9df2bdb3-5ec1-460f-970e-7fbdaca21615?pipeline_id=7b48053d-b5d3-4b39-8b6f-944878d428f5, mypy is no longer complaining