### PR TITLE
Accommodate optional oneofs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.4"
+version="0.2.5"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/codegen/server.py
+++ b/replit_river/codegen/server.py
@@ -98,42 +98,43 @@ def message_decoder(
         chunks.extend(
             [
                 f"  _{oneof.name} = d.get('{to_camel_case(oneof.name)}', {{}})",
-                f"  match _{oneof.name}.get('$kind', None):",
+                f"  if _{oneof.name}:",
+                f"    match _{oneof.name}.get('$kind', None):",
             ]
         )
         for field in oneofs[index]:
             chunks.append(
-                f"      case '{to_camel_case(field.name)}':",
+                f"        case '{to_camel_case(field.name)}':",
             )
             if field.type_name == ".google.protobuf.Timestamp":
                 chunks.extend(
                     [
-                        f"        _{field.name} = timestamp_pb2.Timestamp()"
-                        f"        _{field.name}.FromDatetime(",
-                        f"            _{oneof.name}['{to_camel_case(field.name)}'],",
-                        "        )",
-                        f"        m.{field.name}.MergeFrom(_{field.name})",
+                        f"          _{field.name} = timestamp_pb2.Timestamp()"
+                        f"          _{field.name}.FromDatetime(",
+                        f"              _{oneof.name}['{to_camel_case(field.name)}'],",
+                        "          )",
+                        f"          m.{field.name}.MergeFrom(_{field.name})",
                     ]
                 )
             elif field.label == FieldDescriptor.LABEL_REPEATED:
                 chunks.append(
-                    f"        m.{field.name}.MergeFrom"
+                    f"          m.{field.name}.MergeFrom"
                     f"(_{oneof.name}['{to_camel_case(field.name)}'])"
                 )
             elif field.type == descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE:
                 decode_method_name = get_decoder_name(field)
                 chunks.append(
-                    f"        m.{field.name}.MergeFrom({decode_method_name}"
+                    f"          m.{field.name}.MergeFrom({decode_method_name}"
                     f"(_{oneof.name}['{to_camel_case(field.name)}']))"
                 )
             else:
                 chunks.extend(
                     [
-                        "        setattr(",
-                        "          m,",
-                        f"          '{field.name}',",
-                        f"          _{oneof.name}['{to_camel_case(field.name)}'],",
-                        "        )",
+                        "          setattr(",
+                        "            m,",
+                        f"            '{field.name}',",
+                        f"            _{oneof.name}['{to_camel_case(field.name)}'],",
+                        "          )",
                     ]
                 )
     chunks.extend(


### PR DESCRIPTION
Why
===

We recently codegenned oneofs to be able to be optional, but this was not updated.

What changed
============

This change now lets oneofs be totally optional.

Test plan
=========

https://replit.slack.com/archives/C074CCJSS0M/p1718325825047789?thread_ts=1718303562.767029&cid=C074CCJSS0M