### PR TITLE
A few smol fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.5"
+version="0.2.6"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"


### PR DESCRIPTION
Why
===

The Python implementation of River probably has a few bugs, since we see a large number of invariant violation errors.


What changed
============

This change:

* Stops a few resource leaks: the heartbeat tasks could get into a state where they never terminated, so they would consume a task forever.
* Stops a couple of TOCTOU races where an `await` point could have gotten in the way of a test-and-replace operation (which thanks to the GIL should be "atomic", except that pesky `await` point got in the way).
* Added a comment clarifying the transitions between the session states.
* Deindented a smol block for clarity.

Test plan
=========

Hopefully https://app.datadoghq.com/logs?query=%40river.tags%3Ainvariant-violation%20%40riverTarget%3Aai-chat%20&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&cols=status_line%2Cmatches%2Cvolume%2Cservice%2Cmessage&fromUser=true&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=pattern&x_missing=true&from_ts=1718406678000&to_ts=1718493078000&live=true occur less frequently.