### PR TITLE
Proactively tell the server about our expected state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.6"
+version="0.2.7"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/rpc.py
+++ b/replit_river/rpc.py
@@ -47,10 +47,16 @@ STREAM_CLOSED_BIT = 0x0004
 # Equivalent of https://github.com/replit/river/blob/c1345f1ff6a17a841d4319fad5c153b5bda43827/transport/message.ts#L23-L33
 
 
+class ExpectedSessionState(BaseModel):
+    reconnect: bool
+    nextExpectedSeq: int
+
+
 class ControlMessageHandshakeRequest(BaseModel):
     type: Literal["HANDSHAKE_REQ"] = "HANDSHAKE_REQ"
     protocolVersion: str
     sessionId: str
+    expectedSessionState: Optional[ExpectedSessionState] = None
     metadata: Optional[Any] = None
 
 
@@ -178,7 +184,6 @@ def rpc_method_handler(
     request_deserializer: Callable[[Any], RequestType],
     response_serializer: Callable[[ResponseType], Any],
 ) -> GenericRpcHandler:
-
     async def wrapped(
         peer: str,
         input: Channel[Any],

--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -329,6 +329,14 @@ class Session(object):
         except FailedSendingMessageException as e:
             raise e
 
+    async def get_next_expected_seq(self) -> int:
+        """Get the next expected sequence number from the server."""
+        return await self._seq_manager.get_ack()
+
+    async def get_next_expected_ack(self) -> int:
+        """Get the next expected ack that the client expects."""
+        return await self._seq_manager.get_seq()
+
     async def send_message(
         self,
         stream_id: str,


### PR DESCRIPTION
Why
===

We have a few cases where the server recreates a connection that was meant to be a reconnect.

What changed
============

This change brings the Python implementation in line with the TypeScript one so that the server can proactively tell clients to recreate their sessions. See https://github.com/replit/river/pull/212 for reference

Test plan
=========

Logs like https://app.datadoghq.com/logs?query=%40replid%3Ae2698176-9a19-4058-8619-7f5793b02cde&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2C%40river.sessionId&event=AgAAAZAssKXztskj6QAAAAAAAAAYAAAAAEFaQXNzS2NBQUFBR1hKdG9Bd1NLLVFBbwAAACQAAAAAMDE5MDJjYjItYzE2Ny00YmZiLThjMjctNzdkNjI5Y2NkY2Vj&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1718734624299&to_ts=1718737623927&live=false should completely go away