### PR TITLE
Downgrade session state mismatch from a error to info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.7"
+version="0.2.8"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/seq_manager.py
+++ b/replit_river/seq_manager.py
@@ -16,6 +16,13 @@ class InvalidMessageException(Exception):
     pass
 
 
+class SessionStateMismatchException(Exception):
+    """Error when the session state mismatch, we reject handshake and
+    close the connection"""
+
+    pass
+
+
 class SeqManager:
     """Manages the sequence number and ack number for a connection."""
 

--- a/replit_river/server.py
+++ b/replit_river/server.py
@@ -7,6 +7,7 @@ from websockets.exceptions import ConnectionClosed
 from websockets.server import WebSocketServerProtocol
 
 from replit_river.messages import WebsocketClosedException
+from replit_river.seq_manager import SessionStateMismatchException
 from replit_river.server_transport import ServerTransport
 from replit_river.transport import TransportOptions
 
@@ -47,6 +48,12 @@ class Server(object):
             )
         except (websockets.exceptions.ConnectionClosed, WebsocketClosedException):
             # it is fine if the ws is closed during handshake, we just close the ws
+            await websocket.close()
+            return
+        except SessionStateMismatchException as e:
+            logging.info(
+                f"Session state mismatch, closing websocket: {e}", exc_info=True
+            )
             await websocket.close()
             return
         except Exception as e:

--- a/replit_river/server_transport.py
+++ b/replit_river/server_transport.py
@@ -25,6 +25,7 @@ from replit_river.rpc import (
 from replit_river.seq_manager import (
     IgnoreMessageException,
     InvalidMessageException,
+    SessionStateMismatchException,
 )
 from replit_river.session import Session
 from replit_river.transport import Transport
@@ -47,6 +48,8 @@ class ServerTransport(Transport):
             except InvalidMessageException:
                 error_msg = "Got invalid transport message, closing connection"
                 raise InvalidMessageException(error_msg)
+            except SessionStateMismatchException as e:
+                raise e
             except FailedSendingMessageException as e:
                 raise e
             logging.debug("handshake success on server: %r", handshake_request)
@@ -162,7 +165,7 @@ class ServerTransport(Transport):
                     HandShakeStatus(ok=False, reason="session state mismatch"),
                     websocket,
                 )
-                raise InvalidMessageException("session state mismatch")
+                raise SessionStateMismatchException("session state mismatch")
             my_session_id = maybe_my_session_id
         else:
             my_session_id = self.generate_session_id()


### PR DESCRIPTION
Why
===
Sentry is showing a lot of errors on this 
https://replit-kq.sentry.io/issues/5505514960/events/94b8700cfaa0452ab4ec9f1ea5a45e55/?project=4505943408574464

What changed
============
This is expected when user reconnect to a different server, so it's like a info not a error.

Test plan
=========
river-babel