### PR TITLE
Fix Type.any types issue with Codegen

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -59,7 +59,7 @@ def encode_type(
     if isinstance(type, RiverConcreteType):
         if type.type is None:
             # Handle the case where type is not specified
-            return ("Any", ())  # or some other default behavior
+            return ("Any", ())
         if type.type == "string":
             if type.const:
                 return (f"Literal['{type.const}']", ())

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field, RootModel
 
 
 class RiverConcreteType(BaseModel):
-    type: str
+    type: Optional[str] = Field(default=None)
     properties: Dict[str, "RiverType"] = Field(default_factory=lambda: dict())
     required: Set[str] = Field(default=set())
     items: Optional["RiverType"] = Field(default=None)
@@ -57,6 +57,9 @@ def encode_type(
         chunks.append(f"{prefix} = Union[" + ", ".join(any_of) + "]")
         return (prefix, chunks)
     if isinstance(type, RiverConcreteType):
+        if type.type is None:
+            # Handle the case where type is not specified
+            return ("Any", ())  # or some other default behavior
         if type.type == "string":
             if type.const:
                 return (f"Literal['{type.const}']", ())


### PR DESCRIPTION
Why
===

`Type.any`  is codegened without a type. 

>data (and a few other fields) that are Type.Any are codegenned without a type field https://github.com/replit/ai-infra/pull/1423/files#diff-0dbf721bd6de1d6cb202caf7bd7a1412611f6680972f4748aad5a2e3af623a28R506
We then throw trying to codgen, likely right here https://github.com/replit/river-python/blob/main/replit_river/codegen/client.py#L95
[client.py](https://github.com/replit/river-python/blob/main/replit_river/codegen/client.py)

https://replit.slack.com/archives/C074CCJSS0M/p1719530737158639?thread_ts=1719528490.627619&cid=C074CCJSS0M

What changed
============

Fix the above issue.

Test plan
=========

Generate a client codegen from schema with no type defined.