### PR TITLE
0.2.10: Catch the handshake exception outside of asyncio.wait_for

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.9"
+version="0.2.10"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.8"
+version="0.2.9"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/server.py
+++ b/replit_river/server.py
@@ -9,8 +9,8 @@ from websockets.server import WebSocketServerProtocol
 from replit_river.messages import WebsocketClosedException
 from replit_river.seq_manager import SessionStateMismatchException
 from replit_river.server_transport import ServerTransport
-from replit_river.transport import TransportOptions
 from replit_river.session import Session
+from replit_river.transport import TransportOptions
 
 from .rpc import (
     GenericRpcHandler,

--- a/replit_river/server.py
+++ b/replit_river/server.py
@@ -80,6 +80,10 @@ class Server(object):
             logging.error("Handshake timeout, closing websocket")
             await websocket.close()
             return
+        except asyncio.CancelledError:
+            logging.error("Handshake cancelled, closing websocket")
+            await websocket.close()
+            return
         logging.debug("River server session established, start serving messages")
 
         try:

--- a/replit_river/server.py
+++ b/replit_river/server.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Mapping, Tuple
+from typing import Mapping, Optional, Tuple
 
 import websockets
 from websockets.exceptions import ConnectionClosed
@@ -10,6 +10,7 @@ from replit_river.messages import WebsocketClosedException
 from replit_river.seq_manager import SessionStateMismatchException
 from replit_river.server_transport import ServerTransport
 from replit_river.transport import TransportOptions
+from replit_river.session import Session
 
 from .rpc import (
     GenericRpcHandler,
@@ -37,29 +38,46 @@ class Server(object):
     ) -> None:
         self._transport._handlers.update(rpc_handlers)
 
+    async def _handshake_to_get_session(
+        self, websocket: WebSocketServerProtocol
+    ) -> Optional[Session]:
+        """This is a wrapper to make sentry happy, sentry doesn't recognize the
+        exception handling outside of a task or asyncio.wait_for. So we need to catch
+        the errors specifically here.
+        https://docs.sentry.io/platforms/python/integrations/asyncio/#behavior
+        """
+        try:
+            return await self._transport.handshake_to_get_session(websocket)
+        except (websockets.exceptions.ConnectionClosed, WebsocketClosedException):
+            # it is fine if the ws is closed during handshake, we just close the ws
+            await websocket.close()
+            return None
+        except SessionStateMismatchException as e:
+            logging.info(
+                f"Session state mismatch, closing websocket: {e}", exc_info=True
+            )
+            await websocket.close()
+            return None
+        except Exception as e:
+            logging.error(
+                f"Error establishing handshake, closing websocket: {e}", exc_info=True
+            )
+            await websocket.close()
+            return None
+
     async def serve(self, websocket: WebSocketServerProtocol) -> None:
         logging.debug(
             "River server started establishing session with ws: %s", websocket.id
         )
         try:
             session = await asyncio.wait_for(
-                self._transport.handshake_to_get_session(websocket),
+                self._handshake_to_get_session(websocket),
                 self._transport_options.session_disconnect_grace_ms / 1000,
             )
-        except (websockets.exceptions.ConnectionClosed, WebsocketClosedException):
-            # it is fine if the ws is closed during handshake, we just close the ws
-            await websocket.close()
-            return
-        except SessionStateMismatchException as e:
-            logging.info(
-                f"Session state mismatch, closing websocket: {e}", exc_info=True
-            )
-            await websocket.close()
-            return
-        except Exception as e:
-            logging.error(
-                f"Error establishing handshake, closing websocket: {e}", exc_info=True
-            )
+            if not session:
+                return
+        except asyncio.TimeoutError:
+            logging.error("Handshake timeout, closing websocket")
             await websocket.close()
             return
         logging.debug("River server session established, start serving messages")


### PR DESCRIPTION
Why
===
Sentry doesn't handle exception catching outside of asyncio.wait_for, this leads to a large amount of sentry errors.

What changed
============
We create a wrapper to catch the exceptions before asyncio.wait_for
