### PR TITLE
Allow the codegen to emit the `null` type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.10"
+version="0.2.11"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -76,6 +76,8 @@ def encode_type(
             return ("int", ())
         if type.type == "boolean":
             return ("bool", ())
+        if type.type == "null":
+            return ("None", ())
         if type.type == "Date":
             return ("datetime.datetime", ())
         if type.type == "array" and type.items:


### PR DESCRIPTION
Why
===

Some types have an explicit `Type.Null()` (as opposed to a `Type.Optional`). That's allowed by the spec, so we should support it.

What changed
============

This change now correctly codegens `Type.Null()` (or in JSON-schema parlance, `"type": "null"`) into Python's `None` type.

Test plan
=========

Amended the python file for this in the poetry venv, generating the latest and greatest pid2 schema succeeded.