### PR TITLE
Correctly codegen literal integers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.11"
+version="0.2.12"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -70,9 +70,12 @@ def encode_type(
         if type.type == "number":
             if type.const is not None:
                 # enums are represented as const number in the schema
-                return ("int", ())
+                return (f"Literal[{type.const}]", ())
             return ("float", ())
         if type.type == "integer":
+            if type.const is not None:
+                # enums are represented as const number in the schema
+                return (f"Literal[{type.const}]", ())
             return ("int", ())
         if type.type == "boolean":
             return ("bool", ())


### PR DESCRIPTION
Why
===

We had some trouble codegenning literal integers.

What changed
============

This change now correctly codegens the literal numbers / integers so that we don't have weird `Union[int, int, int, int ...]`s.

Test plan
=========

https://github.com/replit/ai-infra/pull/1444/files#diff-031059c82851dedf73e244834942b7f8c1061cbdbf9ec829e37f0ad236dc4621R340 doesn't happen again.