### PR TITLE
Prevent reconnects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.18"
+version="0.2.19"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"


### PR DESCRIPTION
Why
===

We have some problems with reconnects, and it's probably better to completely disable transparent reconnects until we have that sorted out.

What changed
============

This change now proactively closes and deletes any outstanding sessions when we detect that the WebSocket transport was closed.

Test plan
=========

@cdmistman doesn't get into terrible states.