### PR TITLE
Allow empty client-streams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.14"
+version="0.2.15"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def serialize_request(request: str) -> dict:
 
 
 def deserialize_request(request: dict) -> str:
-    return request["data"] or ""
+    return request.get("data") or ""
 
 
 def serialize_response(response: str) -> dict:
@@ -56,7 +56,7 @@ def serialize_response(response: str) -> dict:
 
 
 def deserialize_response(response: dict) -> str:
-    return response["data"] or ""
+    return response.get("data") or ""
 
 
 def deserialize_error(response: dict) -> RiverError:

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -42,6 +42,25 @@ async def test_upload_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_upload_empty(client: Client) -> None:
+    async def upload_data(enabled: bool = False) -> AsyncGenerator[str, None]:
+        if enabled:
+            yield "unreachable"
+
+    response = await client.send_upload(
+        "test_service",
+        "upload_method",
+        None,
+        upload_data(),
+        None,
+        serialize_request,
+        deserialize_response,
+        deserialize_response,
+    )  # type: ignore
+    assert response == "Uploaded: "
+
+
+@pytest.mark.asyncio
 async def test_subscription_method(client: Client) -> None:
     async for response in await client.send_subscription(
         "test_service",
@@ -80,6 +99,28 @@ async def test_stream_method(client: Client) -> None:
         "Stream response for Stream 2",
         "Stream response for Stream 3",
     ]
+
+
+@pytest.mark.asyncio
+async def test_stream_empty(client: Client) -> None:
+    async def stream_data(enabled: bool = False) -> AsyncGenerator[str, None]:
+        if enabled:
+            yield "unreachable"
+
+    responses = []
+    async for response in await client.send_stream(
+        "test_service",
+        "stream_method",
+        None,
+        stream_data(),
+        None,
+        serialize_request,
+        deserialize_response,
+        deserialize_error,
+    ):
+        responses.append(response)
+
+    assert responses == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Why
===

We currently don't force streams to have an initialization, which means that it is possible for clients to end a stream without having sent any messages. This confuses the server!

What changed
============

This change now allows clients to send empty streams while the protocolv2 change lands.

Test plan
=========

```shell
pytest
```