### PR TITLE
correctly decode optional oneof

### DIFF
--- a/replit_river/codegen/server.py
+++ b/replit_river/codegen/server.py
@@ -96,23 +96,21 @@ def message_decoder(
     # oneof fields.
     for index, oneof in enumerate(m.oneof_decl):
         for fieldIndex, field in enumerate(oneofs[index]):
-            accessor_key = (
-                "d"
-                if field.label == FieldDescriptor.LABEL_OPTIONAL
-                else f"_{oneof.name}"
-            )
+            accessor_key: str
 
             # don't wrap optional fields in additional object
             if field.label == FieldDescriptor.LABEL_OPTIONAL:
+                accessor_key = "d"
                 chunks.append(f"  if d.get('{to_camel_case(field.name)}') is not None:")
             else:
+                accessor_key = f"_{oneof.name}"
                 if fieldIndex == 0:
                     chunks.extend(
                         [
-                            f"_{oneof.name} ="
+                            f"{accessor_key} ="
                             f"d.get('{to_camel_case(oneof.name)}', {{}})",
-                            f"  if _{oneof.name}:",
-                            f"    match _{oneof.name}.get('$kind', None):",
+                            f"  if {accessor_key}:",
+                            f"    match {accessor_key}.get('$kind', None):",
                         ]
                     )
                 chunks.append(f"        case '{to_camel_case(field.name)}':")


### PR DESCRIPTION
Why
===

Our proto to python codegen treats optional fields as "oneof" fields, which expects an wrapper object with a $kind field. This doesn't match what our proto to typebox codegen does.

_Describe what prompted you to make this change, link relevant resources: Linear issues, Slack discussions, etc._

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

I wrote a proto with some optional fields, including an optional object field
![Screenshot 2024-07-12 at 12 47 58 PM](https://github.com/user-attachments/assets/e0d062d4-3c75-4d2d-84b7-50cb437dfe4a)

Generated the decoder correctly, without expecting the wrapper object
![Screenshot 2024-07-12 at 12 47 53 PM](https://github.com/user-attachments/assets/e1f9ee76-748b-4a93-87f1-5d8dad015ea7)


_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
