### PR TITLE
fix infinite task cancellation loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.19"
+version="0.2.10"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -160,6 +160,7 @@ class ClientTransport(Transport):
     async def _retry_connection(self) -> ClientSession:
         """Deletes any outstanding sessions and creates a new one."""
         if not self._transport_options.transparent_reconnect:
+            print("connection dropped and transparent reconn is off, closing all sessions")
             await self._close_all_sessions()
         return await self._get_or_create_session()
 
@@ -303,7 +304,7 @@ class ClientTransport(Transport):
                 # If the session status is mismatched, we should close the old session
                 # and let the retry logic to create a new session.
                 await old_session.close()
-                self._delete_session(old_session)
+                await self._delete_session(old_session)
 
             raise RiverException(
                 ERROR_HANDSHAKE, f"Handshake failed: {handshake_response.status.reason}"

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -159,16 +159,8 @@ class ClientTransport(Transport):
 
     async def _retry_connection(self) -> ClientSession:
         """Deletes any outstanding sessions and creates a new one."""
-        async with self._session_lock:
-            sessions = self._sessions.values()
-            logging.info(
-                f"start closing transport {self._transport_id}, number sessions : "
-                f"{len(sessions)}"
-            )
-            sessions_to_close = list(sessions)
-            self._sessions.clear()
-        tasks = [session.close() for session in sessions_to_close]
-        await asyncio.gather(*tasks)
+        if not self._transport_options.transparent_reconnect:
+            await self._close_all_sessions()
         return await self._get_or_create_session()
 
     async def _get_or_create_session(self) -> ClientSession:

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -129,7 +129,7 @@ class ClientTransport(Transport):
             except Exception as e:
                 backoff_time = rate_limit.get_backoff_ms(client_id)
                 logging.error(
-                    f"Error creating session: {e}, retrying with {backoff_time}ms backoff"
+                    f"Error connecting: {e}, retrying with {backoff_time}ms backoff"
                 )
                 await asyncio.sleep(backoff_time / 1000)
         raise RiverException(

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -160,7 +160,9 @@ class ClientTransport(Transport):
     async def _retry_connection(self) -> ClientSession:
         """Deletes any outstanding sessions and creates a new one."""
         if not self._transport_options.transparent_reconnect:
-            print("connection dropped and transparent reconn is off, closing all sessions")
+            print(
+                "connection dropped and transparent reconn is off, closing all sessions"
+            )
             await self._close_all_sessions()
         return await self._get_or_create_session()
 

--- a/replit_river/server.py
+++ b/replit_river/server.py
@@ -69,15 +69,15 @@ class Server(object):
         logging.debug(
             "River server started establishing session with ws: %s", websocket.id
         )
+        grace_ms = self._transport_options.session_disconnect_grace_ms / 1000
         try:
             session = await asyncio.wait_for(
-                self._handshake_to_get_session(websocket),
-                self._transport_options.session_disconnect_grace_ms / 1000,
+                self._handshake_to_get_session(websocket), grace_ms
             )
             if not session:
                 return
         except asyncio.TimeoutError:
-            logging.error("Handshake timeout, closing websocket")
+            logging.error(f"Handshake timeout after {grace_ms}ms, closing websocket")
             await websocket.close()
             return
         except asyncio.CancelledError:

--- a/replit_river/server_transport.py
+++ b/replit_river/server_transport.py
@@ -189,7 +189,7 @@ class ServerTransport(Transport):
                 # we have an old session but the session id is different
                 # just delete the old session
                 await old_session.close()
-                self._delete_session(old_session)
+                await self._delete_session(old_session)
                 old_session = None
 
             if not old_session and (

--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -433,7 +433,6 @@ class Session(object):
                 return
             await ws_wrapper.close()
         if should_retry and self._retry_connection_callback:
-            print("retrying ws")
             self._task_manager.create_task(self._retry_connection_callback())
 
     async def _open_stream_and_call_handler(
@@ -522,7 +521,6 @@ class Session(object):
             f"to {self._to_id}, ws: {self._ws_wrapper.id}, "
             f"current_state : {self._ws_wrapper.ws_state.name}"
         )
-        print("session closing", self.session_id)
         async with self._state_lock:
             if self._state != SessionState.ACTIVE:
                 # already closing
@@ -531,11 +529,9 @@ class Session(object):
             self._reset_session_close_countdown()
             await self._task_manager.cancel_all_tasks()
 
-            print("closing ws in close()")
             await self.close_websocket(self._ws_wrapper, should_retry=False)
 
             # Clear the session in transports
-            print("calling close session callback")
             await self._close_session_callback(self)
 
             # TODO: unexpected_close should close stream differently here to

--- a/replit_river/transport.py
+++ b/replit_river/transport.py
@@ -35,7 +35,6 @@ class Transport:
         await self._close_all_sessions()
 
     async def _close_all_sessions(self) -> None:
-        print("closing all sessions")
         sessions = self._sessions.values()
         logging.info(
             f"start closing sessions {self._transport_id}, number sessions : "
@@ -51,12 +50,9 @@ class Transport:
         logging.info(f"Transport closed {self._transport_id}")
 
     async def _delete_session(self, session: Session) -> None:
-        print("deleting session", session.session_id)
         async with self._session_lock:
             if session._to_id in self._sessions:
                 del self._sessions[session._to_id]
-
-        print("SUCCESS!")
 
     def _set_session(self, session: Session) -> None:
         self._sessions[session._to_id] = session

--- a/replit_river/transport.py
+++ b/replit_river/transport.py
@@ -35,20 +35,22 @@ class Transport:
         await self._close_all_sessions()
 
     async def _close_all_sessions(self) -> None:
-        async with self._session_lock:
-            sessions = self._sessions.values()
-            logging.info(
-                f"start closing sessions {self._transport_id}, number sessions : "
-                f"{len(sessions)}"
-            )
-            sessions_to_close = list(sessions)
-            tasks = [session.close() for session in sessions_to_close]
-            await asyncio.gather(*tasks)
-            logging.info(f"Transport closed {self._transport_id}")
+        print("closing all sessions")
+        sessions = self._sessions.values()
+        logging.info(
+            f"start closing sessions {self._transport_id}, number sessions : "
+            f"{len(sessions)}"
+        )
+        sessions_to_close = list(sessions)
+        tasks = [session.close() for session in sessions_to_close]
+        await asyncio.gather(*tasks)
+        logging.info(f"Transport closed {self._transport_id}")
 
-    def _delete_session(self, session: Session) -> None:
-        if session._to_id in self._sessions:
-            del self._sessions[session._to_id]
+    async def _delete_session(self, session: Session) -> None:
+        print("deleting session", session.session_id)
+        async with self._session_lock:
+            if session._to_id in self._sessions:
+                del self._sessions[session._to_id]
 
     def _set_session(self, session: Session) -> None:
         self._sessions[session._to_id] = session

--- a/replit_river/transport.py
+++ b/replit_river/transport.py
@@ -35,15 +35,16 @@ class Transport:
         await self._close_all_sessions()
 
     async def _close_all_sessions(self) -> None:
-        sessions = self._sessions.values()
-        logging.info(
-            f"start closing transport {self._transport_id}, number sessions : "
-            f"{len(sessions)}"
-        )
-        sessions_to_close = list(sessions)
-        tasks = [session.close() for session in sessions_to_close]
-        await asyncio.gather(*tasks)
-        logging.info(f"Transport closed {self._transport_id}")
+        async with self._session_lock:
+            sessions = self._sessions.values()
+            logging.info(
+                f"start closing sessions {self._transport_id}, number sessions : "
+                f"{len(sessions)}"
+            )
+            sessions_to_close = list(sessions)
+            tasks = [session.close() for session in sessions_to_close]
+            await asyncio.gather(*tasks)
+            logging.info(f"Transport closed {self._transport_id}")
 
     def _delete_session(self, session: Session) -> None:
         if session._to_id in self._sessions:

--- a/replit_river/transport_options.py
+++ b/replit_river/transport_options.py
@@ -19,10 +19,10 @@ class ConnectionRetryOptions(BaseModel):
 # setup in replit web can be found at
 # https://github.com/replit/repl-it-web/blob/main/pkg/pid2/src/entrypoints/protocol.ts#L13
 class TransportOptions(BaseModel):
-    session_disconnect_grace_ms: float = 5_000
-    heartbeat_ms: float = 500
+    session_disconnect_grace_ms: float = 10_000
+    heartbeat_ms: float = 2_500
     # TODO: This should have a better name like max_failed_heartbeats
-    heartbeats_until_dead: int = 2
+    heartbeats_until_dead: int = 4
     use_prefix_bytes: bool = False
     close_session_check_interval_ms: float = 100
     connection_retry_options: ConnectionRetryOptions = ConnectionRetryOptions()

--- a/replit_river/transport_options.py
+++ b/replit_river/transport_options.py
@@ -21,12 +21,13 @@ class ConnectionRetryOptions(BaseModel):
 class TransportOptions(BaseModel):
     session_disconnect_grace_ms: float = 5_000
     heartbeat_ms: float = 500
-    # TODO: This shoudl have a better name like max_failed_heartbeats
+    # TODO: This should have a better name like max_failed_heartbeats
     heartbeats_until_dead: int = 2
     use_prefix_bytes: bool = False
     close_session_check_interval_ms: float = 100
     connection_retry_options: ConnectionRetryOptions = ConnectionRetryOptions()
     buffer_size: int = 1_000
+    transparent_reconnect: bool = False
 
     def get_prefix_bytes(self) -> bytes:
         return PID2_PREFIX_BYTES if self.use_prefix_bytes else b""

--- a/replit_river/transport_options.py
+++ b/replit_river/transport_options.py
@@ -27,7 +27,7 @@ class TransportOptions(BaseModel):
     close_session_check_interval_ms: float = 100
     connection_retry_options: ConnectionRetryOptions = ConnectionRetryOptions()
     buffer_size: int = 1_000
-    transparent_reconnect: bool = False
+    transparent_reconnect: bool = True
 
     def get_prefix_bytes(self) -> bytes:
         return PID2_PREFIX_BYTES if self.use_prefix_bytes else b""


### PR DESCRIPTION
Why
===

- if we ever disconnected, shit would be bad

What changed
============

- add specific `transparent_reconnect` option
- make `_delete_session` async because it needs to acquire a lock
- lock the things appropriately

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
