### PR TITLE
Also close the WebSocket when we close the session

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.19"
+version="0.2.20"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"

--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -536,4 +536,5 @@ class Session(object):
                 stream.close()
             async with self._stream_lock:
                 self._streams.clear()
+            await self.close_websocket(self._ws_wrapper, should_retry=False)
             self._state = SessionState.CLOSED


### PR DESCRIPTION
Why
===

When we're closing sessions, we do not close the WebSocket and instead kinda rely on the server kicking us out due to inactivity. This makes it racy for cases like connection retries (which we have disabled and instead close any previous sessions), where we can have two concurrent connections for the same session id. An invariant violation!

What changed
============

This change now also makes sure to close the WebSocket when the session is closed.

Test plan
=========

See fewer instances of double concurrent conns.