### PR TITLE
Use module-scoped loggers instead of throwing everything in the root logger

### DIFF
--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -12,6 +12,8 @@ from .rpc import (
     ResponseType,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class Client:
     def __init__(
@@ -33,9 +35,9 @@ class Client:
         )
 
     async def close(self) -> None:
-        logging.info(f"river client {self._client_id} start closing")
+        logger.info(f"river client {self._client_id} start closing")
         await self._transport.close()
-        logging.info(f"river client {self._client_id} closed")
+        logger.info(f"river client {self._client_id} closed")
 
     async def send_rpc(
         self,

--- a/replit_river/client_session.py
+++ b/replit_river/client_session.py
@@ -19,6 +19,8 @@ from .rpc import (
     ResponseType,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class ClientSession(Session):
     async def send_rpc(
@@ -176,7 +178,7 @@ class ClientSession(Session):
                     try:
                         yield error_deserializer(item["payload"])
                     except Exception:
-                        logging.exception(
+                        logger.exception(
                             f"Error during subscription error deserialization: {item}"
                         )
                     continue
@@ -269,7 +271,7 @@ class ClientSession(Session):
                     try:
                         yield error_deserializer(item["payload"])
                     except Exception:
-                        logging.exception(
+                        logger.exception(
                             f"Error during subscription error deserialization: {item}"
                         )
                     continue

--- a/replit_river/message_buffer.py
+++ b/replit_river/message_buffer.py
@@ -5,6 +5,8 @@ from typing import Optional
 from replit_river.rpc import TransportMessage
 from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE
 
+logger = logging.getLogger(__name__)
+
 
 class MessageBuffer:
     """A buffer to store messages and support current updates"""
@@ -23,7 +25,7 @@ class MessageBuffer:
         """Add a message to the buffer"""
         async with self._lock:
             if len(self.buffer) >= self.max_size:
-                logging.error("Buffer is full, dropping message")
+                logger.error("Buffer is full, dropping message")
                 raise ValueError("Buffer is full")
             self.buffer.append(message)
 

--- a/replit_river/messages.py
+++ b/replit_river/messages.py
@@ -18,6 +18,8 @@ from replit_river.seq_manager import (
 )
 from replit_river.transport_options import TransportOptions
 
+logger = logging.getLogger(__name__)
+
 
 class WebsocketClosedException(Exception):
     pass
@@ -39,7 +41,7 @@ async def send_transport_message(
     websocket_closed_callback: Callable[[], Coroutine[Any, Any, None]],
     prefix_bytes: bytes = b"",
 ) -> None:
-    logging.debug("sending a message %r to ws %s", msg, ws)
+    logger.debug("sending a message %r to ws %s", msg, ws)
     try:
         await ws.send(
             prefix_bytes

--- a/replit_river/rpc.py
+++ b/replit_river/rpc.py
@@ -30,6 +30,8 @@ from replit_river.error_schema import (
 from replit_river.task_manager import BackgroundTaskManager
 from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE
 
+logger = logging.getLogger(__name__)
+
 InitType = TypeVar("InitType")
 RequestType = TypeVar("RequestType")
 ResponseType = TypeVar("ResponseType")
@@ -219,7 +221,7 @@ def rpc_method_handler(
                 }
             )
         except Exception as e:
-            logging.exception("Uncaught exception during river rpc")
+            logger.exception("Uncaught exception during river rpc")
             await output.put(
                 {
                     "ok": False,
@@ -268,7 +270,7 @@ def subscription_method_handler(
                 }
             )
         except Exception as e:
-            logging.exception("Uncaught exception in river server subscription")
+            logger.exception("Uncaught exception in river server subscription")
             await output.put(
                 {
                     "ok": False,
@@ -318,7 +320,7 @@ def upload_method_handler(
                 except ChannelClosed:
                     raise RiverException(ERROR_CODE_STREAM_CLOSED, "Channel closed")
                 except Exception as e:
-                    logging.error("Uncaught exception in river server upload")
+                    logger.error("Uncaught exception in river server upload")
                     await output.put(
                         {
                             "ok": False,
@@ -336,7 +338,7 @@ def upload_method_handler(
             await asyncio.wait((convert_inputs_task, convert_outputs_task))
 
         except Exception as e:
-            logging.exception("Uncaught exception in upload")
+            logger.exception("Uncaught exception in upload")
             await output.put(
                 {
                     "ok": False,
@@ -394,7 +396,7 @@ def stream_method_handler(
             convert_outputs_task = task_manager.create_task(_convert_outputs())
             await asyncio.wait((convert_inputs_task, convert_outputs_task))
         except grpc.RpcError:
-            logging.exception("RPC exception in stream")
+            logger.exception("RPC exception in stream")
             code = grpc.StatusCode(context._abort_code).name if context else "UNKNOWN"
             message = (
                 f"{method.__name__} threw an exception: "
@@ -410,7 +412,7 @@ def stream_method_handler(
                 }
             )
         except Exception as e:
-            logging.exception("Uncaught exception in stream")
+            logger.exception("Uncaught exception in stream")
             await output.put(
                 {
                     "ok": False,

--- a/replit_river/seq_manager.py
+++ b/replit_river/seq_manager.py
@@ -3,6 +3,8 @@ import logging
 
 from replit_river.rpc import TransportMessage
 
+logger = logging.getLogger(__name__)
+
 
 class IgnoreMessageException(Exception):
     """Exception to ignore a transport message, but good to continue."""
@@ -66,7 +68,7 @@ class SeqManager:
                         f" expected {self.ack}"
                     )
                 else:
-                    logging.error(
+                    logger.error(
                         f"Out of order message received got {msg.seq} expected "
                         f"{self.ack}"
                     )

--- a/replit_river/server_transport.py
+++ b/replit_river/server_transport.py
@@ -30,6 +30,8 @@ from replit_river.seq_manager import (
 from replit_river.session import Session
 from replit_river.transport import Transport
 
+logger = logging.getLogger(__name__)
+
 
 class ServerTransport(Transport):
     async def handshake_to_get_session(
@@ -52,7 +54,7 @@ class ServerTransport(Transport):
                 raise e
             except FailedSendingMessageException as e:
                 raise e
-            logging.debug("handshake success on server: %r", handshake_request)
+            logger.debug("handshake success on server: %r", handshake_request)
             transport_id = msg.to
             to_id = msg.from_
             session_id = handshake_response.status.sessionId
@@ -97,7 +99,7 @@ class ServerTransport(Transport):
         )
 
         async def websocket_closed_callback() -> None:
-            logging.error("websocket closed before handshake response")
+            logger.error("websocket closed before handshake response")
 
         try:
             await send_transport_message(
@@ -119,7 +121,7 @@ class ServerTransport(Transport):
             handshake_request = ControlMessageHandshakeRequest(
                 **request_message.payload
             )
-            logging.debug('Got handshake request "%r"', handshake_request)
+            logger.debug('Got handshake request "%r"', handshake_request)
         except (ValidationError, ValueError):
             await self._send_handshake_response(
                 request_message,

--- a/replit_river/task_manager.py
+++ b/replit_river/task_manager.py
@@ -4,6 +4,8 @@ from typing import Any, Optional, Set
 
 from replit_river.error_schema import ERROR_CODE_STREAM_CLOSED, RiverException
 
+logger = logging.getLogger(__name__)
+
 
 class BackgroundTaskManager:
     """Manages background tasks and logs exceptions."""
@@ -34,14 +36,14 @@ class BackgroundTaskManager:
         except asyncio.CancelledError:
             # If we cancel the task manager we will get called here as well,
             # if we want to handle the cancellation differently we can do it here.
-            logging.debug("Task was cancelled %r", task_to_remove)
+            logger.debug("Task was cancelled %r", task_to_remove)
         except RiverException as e:
             if e.code == ERROR_CODE_STREAM_CLOSED:
                 # Task is cancelled
                 pass
-            logging.error("Exception on cancelling task: %r", e, exc_info=True)
+            logger.error("Exception on cancelling task: %r", e, exc_info=True)
         except Exception as e:
-            logging.error("Exception on cancelling task: %r", e, exc_info=True)
+            logger.error("Exception on cancelling task: %r", e, exc_info=True)
         finally:
             # Remove the task from the set regardless of the outcome
             background_tasks.discard(task_to_remove)
@@ -65,7 +67,7 @@ class BackgroundTaskManager:
         except asyncio.CancelledError:
             return
         except Exception:
-            logging.error("Error retrieving task exception", exc_info=True)
+            logger.error("Error retrieving task exception", exc_info=True)
             return
         if exception:
             if (
@@ -75,7 +77,7 @@ class BackgroundTaskManager:
                 # Task is cancelled
                 pass
             else:
-                logging.error(
+                logger.error(
                     "Exception on cancelling task: %r", exception, exc_info=True
                 )
 

--- a/replit_river/transport.py
+++ b/replit_river/transport.py
@@ -12,6 +12,8 @@ from replit_river.rpc import (
 from replit_river.session import Session
 from replit_river.transport_options import TransportOptions
 
+logger = logging.getLogger(__name__)
+
 
 class Transport:
     def __init__(
@@ -36,7 +38,7 @@ class Transport:
 
     async def _close_all_sessions(self) -> None:
         sessions = self._sessions.values()
-        logging.info(
+        logger.info(
             f"start closing sessions {self._transport_id}, number sessions : "
             f"{len(sessions)}"
         )
@@ -47,7 +49,7 @@ class Transport:
         for session in sessions_to_close:
             await session.close()
 
-        logging.info(f"Transport closed {self._transport_id}")
+        logger.info(f"Transport closed {self._transport_id}")
 
     async def _delete_session(self, session: Session) -> None:
         async with self._session_lock:
@@ -71,7 +73,7 @@ class Transport:
             session_to_close: Optional[Session] = None
             new_session: Optional[Session] = None
             if to_id not in self._sessions:
-                logging.debug(
+                logger.debug(
                     'Creating new session with "%s" using ws: %s', to_id, websocket.id
                 )
                 new_session = Session(
@@ -87,7 +89,7 @@ class Transport:
             else:
                 old_session = self._sessions[to_id]
                 if old_session.session_id != session_id:
-                    logging.debug(
+                    logger.debug(
                         'Create new session with "%s" for session id %s'
                         " and close old session %s",
                         to_id,
@@ -108,7 +110,7 @@ class Transport:
                 else:
                     # If the instance id is the same, we reuse the session and assign
                     # a new websocket to it.
-                    logging.debug(
+                    logger.debug(
                         'Reuse old session with "%s" using new ws: %s',
                         to_id,
                         websocket.id,
@@ -120,7 +122,7 @@ class Transport:
                         raise e
 
             if session_to_close:
-                logging.debug("Closing stale session %s", session_to_close.session_id)
+                logger.debug("Closing stale session %s", session_to_close.session_id)
                 await session_to_close.close()
             self._set_session(new_session)
         return new_session

--- a/replit_river/websocket_wrapper.py
+++ b/replit_river/websocket_wrapper.py
@@ -4,6 +4,8 @@ import logging
 
 from websockets import WebSocketCommonProtocol
 
+logger = logging.getLogger(__name__)
+
 
 class WsState(enum.Enum):
     OPEN = 0
@@ -28,6 +30,6 @@ class WebsocketWrapper:
                 self.ws_state = WsState.CLOSING
                 task = asyncio.create_task(self.ws.close())
                 task.add_done_callback(
-                    lambda _: logging.debug("old websocket %s closed.", self.ws.id)
+                    lambda _: logger.debug("old websocket %s closed.", self.ws.id)
                 )
                 self.ws_state = WsState.CLOSED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
 import asyncio
 import logging
 from collections.abc import AsyncIterator
-from typing import Any, AsyncGenerator, Generator
-from unittest.mock import MagicMock, patch
+from typing import Any, AsyncGenerator
 
 import nanoid  # type: ignore
 import pytest
@@ -20,6 +19,10 @@ from replit_river.rpc import (
 )
 from replit_river.server import Server
 from replit_river.transport_options import TransportOptions
+from tests.river_fixtures.logging import NoErrors
+
+# Modular fixtures
+pytest_plugins = ["tests.river_fixtures.logging"]
 
 
 def transport_message(
@@ -129,14 +132,10 @@ def server(transport_options: TransportOptions) -> Server:
 
 
 @pytest.fixture
-def no_logging_error() -> Generator[MagicMock, None, None]:
-    with patch("logging.error") as mock_error:
-        yield mock_error
-
-
-@pytest.fixture
 async def client(
-    server: Server, transport_options: TransportOptions, no_logging_error: MagicMock
+    server: Server,
+    transport_options: TransportOptions,
+    no_logging_error: NoErrors,
 ) -> AsyncGenerator[Client, None]:
     try:
         async with serve(server.serve, "localhost", 8765):
@@ -156,8 +155,4 @@ async def client(
         logging.debug("Start closing test server")
         await server.close()
         # Server should close normally
-        no_logging_error.assert_not_called()
-
-        # Make sure we get called at least once, when we expect it
-        logging.error("An error occurred! /s")
-        no_logging_error.assert_called()
+        no_logging_error()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,3 +157,7 @@ async def client(
         await server.close()
         # Server should close normally
         no_logging_error.assert_not_called()
+
+        # Make sure we get called at least once, when we expect it
+        logging.error("An error occurred! /s")
+        no_logging_error.assert_called()

--- a/tests/river_fixtures/logging.py
+++ b/tests/river_fixtures/logging.py
@@ -1,0 +1,28 @@
+import logging
+from typing import Generator
+
+import pytest
+from pytest import LogCaptureFixture
+
+
+class NoErrors:
+    """
+    A pivot point which can be used to assert that we have received
+    no errors during a test run.
+    """
+
+    caplog: LogCaptureFixture
+
+    def __init__(self, caplog: LogCaptureFixture):
+        self.caplog = caplog
+
+    def __call__(self) -> None:
+        assert len(self.caplog.get_records("setup")) == 0
+        assert len(self.caplog.get_records("call")) == 0
+        assert len(self.caplog.get_records("teardown")) == 0
+
+
+@pytest.fixture
+def no_logging_error(caplog: LogCaptureFixture) -> Generator[NoErrors, None, None]:
+    with caplog.at_level(logging.ERROR):
+        yield NoErrors(caplog)


### PR DESCRIPTION
Why
===

Currently, there's no way to control the log level of individual parts of code. I actually don't care about individual telemetry errors in river, and the output obscures useful errors that come from the rest of the ai-infra agent eval project.

What changed
============

Every logger is now scoped by `__name__`, so we'll see names like `ERROR:replit_river.session:Error while sending responses` instead of just `ERROR:root:Error while sending responses`.

In the following case...
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/1e3f375b-a5a7-4916-8fd9-3641c172b8b7">

I will now be able to say

```python
logging.getLogger('replit_river.client_transport').disabled = True
```
(or similar via ini config or some other logging config) to suppress these.

Test plan
=========

Do we see more explicit logger names?