### PR TITLE
chore/GHA release infrastructure

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '🤖 Dependencies'
+    label: 'dependencies'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,49 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'What version to use for the release'
+        required: true
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade poetry
+
+    - name: Set release version
+      run: |
+        tag="${{ github.event.inputs.version }}"
+        if [ -z "$tag" ]; then
+          tag="${GITHUB_REF_NAME}"
+        fi
+        version="${tag#v}"  # Strip leading v
+
+        # Bump poetry tag
+        poetry version "$version"
+
+    - name: Build and publish
+      run: |
+        poetry install
+        poetry build
+        POETRY_PYPI_TOKEN_PYPI="${{ secrets.PYPI_TOKEN }}" \
+        poetry publish


### PR DESCRIPTION
Why
===

Similar to [replit-py](https://github.com/replit/replit-py) and [replit-object-storage](https://github.com/replit/replit-object-storage-python), we should have a Release-oriented release process. This gives increased visibility into how our libraries change from version to version, as well as offering consistency for maintainers releasing changes.

What changed
============

- Adding a [`release-drafter`](https://github.com/release-drafter/release-drafter) config. This must be done before adding the workflow in a second PR, since the workflow always accesses the default branch for its configuration.
- Adding a `python-publish` action that publishes an update any time a new release is cut

Test plan
=========

Once merged, it should be possible to trigger the workflow to publish a new version of the library via workflow_dispatch or creating a release