### PR TITLE
chore/Adding release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,33 @@
+name: Release Drafter
+
+on:
+  workflow_dispatch: {}
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,17 @@ This includes the necessary machinery to act as a client or server for River:
 
 ## Publishing
 
-Make sure you have pypi token setup, easiest way is to set env var `POETRY_PYPI_TOKEN_PYPI`.
+### Release Drafts
+Pending releases are curated by [release-drafter/release-drafter](https://github.com/release-drafter/release-drafter) on the [Releases](https://github.com/replit/river-python/releases) page.
 
-- update version either manually or via `poetry version`
-- `poetry build`
-- `poetry publish`
+Maintainers can see the next `Draft` release, regenerated every time [release-drafter.yml](https://github.com/replit/river-python/actions/workflows/release-drafter.yml) is triggered.
+
+### PR Labeling
+
+PRs merged since the last release are considered, with the labels on those PRs used for release metadata. `feature`, `bug`, `chore`, and `dependencies` are used for categorization, `major`, `minor`, and `patch` are used to influence the next release's version.
+
+These labels can be altered after merge, re-trigger release-drafter to get it to regenerate the draft once you've curated the next release.
+
+### Triggering release
+
+The tag version is used to set the version during the build, the value in `pyproject.toml` is not expected to be kept up-to-date.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name="replit-river"
-version="0.2.20"
+version="0.0.0a0"
 description="Replit river toolkit for Python"
 authors = ["Replit <eng@replit.com>"]
 license = "LICENSE"


### PR DESCRIPTION
Why
===

Follow-up to #54, enable `release-drafter`.

What changed
============

Adding the release-drafter action to consume the configuration and curate release drafts on every merge to the default branch.

Test plan
=========

When this PR gets merged, do we get a new release draft?