### PR TITLE
Improve logging / exception hygiene

### DIFF
--- a/replit_river/client_session.py
+++ b/replit_river/client_session.py
@@ -52,15 +52,15 @@ class ClientSession(Session):
                 response = await output.get()
             except ChannelClosed as e:
                 raise RiverException(
-                    ERROR_CODE_STREAM_CLOSED, f"Stream closed before response {e}"
-                )
+                    ERROR_CODE_STREAM_CLOSED, "Stream closed before response"
+                ) from e
             except RuntimeError as e:
-                raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e))
+                raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e)) from e
             if not response.get("ok", False):
                 try:
                     error = error_deserializer(response["payload"])
                 except Exception as e:
-                    raise RiverException("error_deserializer", str(e))
+                    raise RiverException("error_deserializer", str(e)) from e
                 raise RiverException(error.code, error.message)
             return response_deserializer(response["payload"])
         except RiverException as e:
@@ -113,7 +113,7 @@ class ClientSession(Session):
                     payload=request_serializer(item),
                 )
         except Exception as e:
-            raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e))
+            raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e)) from e
         await self.send_close_stream(
             service_name,
             procedure_name,
@@ -126,17 +126,17 @@ class ClientSession(Session):
         try:
             try:
                 response = await output.get()
-            except ChannelClosed:
+            except ChannelClosed as e:
                 raise RiverException(
                     ERROR_CODE_STREAM_CLOSED, "Stream closed before response"
-                )
+                ) from e
             except RuntimeError as e:
-                raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e))
+                raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e)) from e
             if not response.get("ok", False):
                 try:
                     error = error_deserializer(response["payload"])
                 except Exception as e:
-                    raise RiverException("error_deserializer", str(e))
+                    raise RiverException("error_deserializer", str(e)) from e
                 raise RiverException(error.code, error.message)
 
             return response_deserializer(response["payload"])
@@ -183,10 +183,10 @@ class ClientSession(Session):
                         )
                     continue
                 yield response_deserializer(item["payload"])
-        except (RuntimeError, ChannelClosed):
+        except (RuntimeError, ChannelClosed) as e:
             raise RiverException(
                 ERROR_CODE_STREAM_CLOSED, "Stream closed before response"
-            )
+            ) from e
         except Exception as e:
             raise e
 
@@ -235,7 +235,7 @@ class ClientSession(Session):
             empty_stream = True
 
         except Exception as e:
-            raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e))
+            raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e)) from e
 
         # Create the encoder task
         async def _encode_stream() -> None:
@@ -276,10 +276,10 @@ class ClientSession(Session):
                         )
                     continue
                 yield response_deserializer(item["payload"])
-        except (RuntimeError, ChannelClosed):
+        except (RuntimeError, ChannelClosed) as e:
             raise RiverException(
                 ERROR_CODE_STREAM_CLOSED, "Stream closed before response"
-            )
+            ) from e
         except Exception as e:
             raise e
 

--- a/replit_river/error_schema.py
+++ b/replit_river/error_schema.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List, Optional
 
 from pydantic import BaseModel
 
@@ -21,3 +21,24 @@ class RiverException(Exception):
         self.code = code
         self.message = message
         super().__init__(f"Error in river, code: {code}, message: {message}")
+
+
+def stringify_exception(e: BaseException, limit: int = 10) -> str:
+    """Return a string representation of an Exception.
+
+    This is different from just calling str(e) because it will also show the
+    chained exceptions as context.
+    """
+    if e.__cause__ is None:
+        # If there are no causes, just fall back to stringifying the exception.
+        return str(e)
+    causes: List[str] = []
+    cause: Optional[BaseException] = e
+    while cause and limit:
+        causes.append(str(cause))
+        cause = cause.__cause__
+        limit -= 1
+    if cause:
+        # If there are still causes remaining, just add an ellipsis.
+        causes.append("...")
+    return ": ".join(causes)

--- a/replit_river/rpc.py
+++ b/replit_river/rpc.py
@@ -26,6 +26,7 @@ from replit_river.error_schema import (
     ERROR_CODE_STREAM_CLOSED,
     RiverError,
     RiverException,
+    stringify_exception,
 )
 from replit_river.task_manager import BackgroundTaskManager
 from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE
@@ -227,7 +228,10 @@ def rpc_method_handler(
                     "ok": False,
                     "payload": {
                         "code": "UNCAUGHT_EXCEPTION",
-                        "message": f"{method.__name__} threw an exception: {e}",
+                        "message": (
+                            f"{method.__name__} threw an "
+                            f"exception: {stringify_exception(e)}"
+                        ),
                     },
                 }
             )
@@ -276,7 +280,10 @@ def subscription_method_handler(
                     "ok": False,
                     "payload": {
                         "code": "UNCAUGHT_EXCEPTION",
-                        "message": f"{method.__name__} threw an exception: {e}",
+                        "message": (
+                            f"{method.__name__} threw an "
+                            f"exception: {stringify_exception(e)}"
+                        ),
                     },
                 }
             )
@@ -320,13 +327,16 @@ def upload_method_handler(
                 except ChannelClosed:
                     raise RiverException(ERROR_CODE_STREAM_CLOSED, "Channel closed")
                 except Exception as e:
-                    logger.error("Uncaught exception in river server upload")
+                    logger.exception("Uncaught exception in river server upload")
                     await output.put(
                         {
                             "ok": False,
                             "payload": {
                                 "code": "UNCAUGHT_EXCEPTION",
-                                "message": f"{method.__name__} threw an exception: {e}",
+                                "message": (
+                                    f"{method.__name__} threw an "
+                                    f"exception: {stringify_exception(e)}"
+                                ),
                             },
                         }
                     )
@@ -344,7 +354,10 @@ def upload_method_handler(
                     "ok": False,
                     "payload": {
                         "code": "UNCAUGHT_EXCEPTION",
-                        "message": f"{method.__name__} threw an exception: {e}",
+                        "message": (
+                            f"{method.__name__} threw an "
+                            f"exception: {stringify_exception(e)}"
+                        ),
                     },
                 }
             )
@@ -418,7 +431,10 @@ def stream_method_handler(
                     "ok": False,
                     "payload": {
                         "code": "UNCAUGHT_EXCEPTION",
-                        "message": f"{method.__name__} threw an exception: {e}",
+                        "message": (
+                            f"{method.__name__} threw an "
+                            f"exception: {stringify_exception(e)}"
+                        ),
                     },
                 }
             )

--- a/replit_river/server.py
+++ b/replit_river/server.py
@@ -54,15 +54,13 @@ class Server(object):
             # it is fine if the ws is closed during handshake, we just close the ws
             await websocket.close()
             return None
-        except SessionStateMismatchException as e:
-            logger.info(
-                f"Session state mismatch, closing websocket: {e}", exc_info=True
-            )
+        except SessionStateMismatchException:
+            logger.info("Session state mismatch, closing websocket", exc_info=True)
             await websocket.close()
             return None
-        except Exception as e:
+        except Exception:
             logger.error(
-                f"Error establishing handshake, closing websocket: {e}", exc_info=True
+                "Error establishing handshake, closing websocket", exc_info=True
             )
             await websocket.close()
             return None
@@ -95,9 +93,9 @@ class Server(object):
             # session should be kept in order to be reused by the reconnect within the
             # grace period.
             await session.serve()
-        except ConnectionClosed as e:
-            logger.debug("ConnectionClosed while serving %r", e)
+        except ConnectionClosed:
+            logger.debug("ConnectionClosed while serving", exc_info=True)
             # We don't have to close the websocket here, it is already closed.
-        except Exception as e:
-            logger.error(f"River transport error in server {self._server_id}: {e}")
+        except Exception:
+            logger.exception("River transport error in server %s", self._server_id)
             await websocket.close()

--- a/replit_river/task_manager.py
+++ b/replit_river/task_manager.py
@@ -41,9 +41,9 @@ class BackgroundTaskManager:
             if e.code == ERROR_CODE_STREAM_CLOSED:
                 # Task is cancelled
                 pass
-            logger.error("Exception on cancelling task: %r", e, exc_info=True)
-        except Exception as e:
-            logger.error("Exception on cancelling task: %r", e, exc_info=True)
+            logger.exception("Exception on cancelling task")
+        except Exception:
+            logger.exception("Exception on cancelling task")
         finally:
             # Remove the task from the set regardless of the outcome
             background_tasks.discard(task_to_remove)
@@ -78,7 +78,8 @@ class BackgroundTaskManager:
                 pass
             else:
                 logger.error(
-                    "Exception on cancelling task: %r", exception, exc_info=True
+                    "Exception on cancelling task",
+                    exc_info=exception,
                 )
 
     def create_task(


### PR DESCRIPTION
Why
===

We currently have some places where exceptions are not chained using the `raise ... from` statement, but rather just the message is added to another exception. That's suboptimal because we lose a lot of context.

What changed
============

This change now tries to use `raise ... from` in more places. Also, all error logs that embed an exception into the log entry now use `logging.exception` (which is equivalent plus it tacks the exception into the `exc_info` field), and other logs that embed the exception message into the log use `exc_info` instead (either setting it to `True` if it is logging in an `except` block, or manually setting the
  `exc_info` to the `BaseException` instance). Also, it surfaces
  exception chains in the stringification for uncaught errors.

Test plan
=========

:eyes: on :dog:.