### PR TITLE
client reconnect on server conn close, more logs

### DIFF
--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -98,7 +98,7 @@ class ClientTransport(Transport):
         rate_limit = self._rate_limiter
         max_retry = self._transport_options.connection_retry_options.max_retry
         client_id = self._client_id
-        logger.info(f"Attempting to establish new ws connection")
+        logger.info("Attempting to establish new ws connection")
         for i in range(max_retry):
             if i > 0:
                 logger.info(f"Retrying build handshake number {i} times")

--- a/replit_river/transport.py
+++ b/replit_river/transport.py
@@ -73,7 +73,7 @@ class Transport:
             session_to_close: Optional[Session] = None
             new_session: Optional[Session] = None
             if to_id not in self._sessions:
-                logger.debug(
+                logger.info(
                     'Creating new session with "%s" using ws: %s', to_id, websocket.id
                 )
                 new_session = Session(
@@ -89,7 +89,7 @@ class Transport:
             else:
                 old_session = self._sessions[to_id]
                 if old_session.session_id != session_id:
-                    logger.debug(
+                    logger.info(
                         'Create new session with "%s" for session id %s'
                         " and close old session %s",
                         to_id,
@@ -122,7 +122,7 @@ class Transport:
                         raise e
 
             if session_to_close:
-                logger.debug("Closing stale session %s", session_to_close.session_id)
+                logger.info("Closing stale session %s", session_to_close.session_id)
                 await session_to_close.close()
             self._set_session(new_session)
         return new_session


### PR DESCRIPTION
Why + What changed
===

_Describe what prompted you to make this change, link relevant resources: Linear issues, Slack discussions, etc._

- if the server closed the conn, we never tried to reconnect as a client
- we are also seeing cases where pid2 doesnt receive a heartbeat in time so it closes the connection so I added some more logs for o11y around session lifetimes

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
