### PR TITLE
[bug] Fix runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["rpc", "websockets"]
 readme = "README.md"
 
 [tool.poetry.scripts]
-river-codegen-py = "river.codegen:run"
+river-codegen-py = "replit_river.codegen.run:main"
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
Why
===

Modules seem to have been shifted around a bit, fix this

What changed
============

Specify the correct path to the `main` function

Test plan
=========

Run `river-codegen-py`, observe that it can be used