### PR TITLE
bug/Type union ignore-arg

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -1,5 +1,6 @@
 import json
 import re
+from textwrap import dedent, indent
 from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union
 
 import black
@@ -273,41 +274,59 @@ def generate_river_client_module(
                     control_flow_keyword = ""
                 current_chunks.extend(
                     [
-                        f"  async def {name}(",
-                        "    self,",
-                        f"    input: {input_type},",
-                        f"  ) -> {output_type}:"
-                        f"    {control_flow_keyword}await self.client.send_rpc(",
-                        f"      '{schema_name}',",
-                        f"      '{name}',",
-                        "      input,",
-                        f"      lambda x: TypeAdapter({input_type}).dump_python(x, ",
-                        "        by_alias=True,",
-                        "        exclude_none=True,",
-                        "      ),",
-                        f"     {parse_output_method}",
-                        f"     {parse_error_method}",
-                        "    )",
+                        indent(
+                            dedent(
+                                f"""\
+                    async def {name}(
+                      self,
+                      input: {input_type},
+                    ) -> {output_type}:
+                      {control_flow_keyword}await self.client.send_rpc(
+                        '{schema_name}',
+                        '{name}',
+                        input,
+                        lambda x: TypeAdapter({input_type})
+                          .dump_python(
+                            x,
+                            by_alias=True,
+                            exclude_none=True,
+                          ),
+                        {parse_output_method}
+                        {parse_error_method}
+                      )
+                        """
+                            ),
+                            "  ",
+                        )
                     ]
                 )
             elif procedure.type == "subscription":
                 current_chunks.extend(
                     [
-                        f"  async def {name}(",
-                        "    self,",
-                        f"    input: {input_type},",
-                        f") -> AsyncIterator[{output_or_error_type}]:",
-                        "    return await self.client.send_subscription(",
-                        f"      '{schema_name}',",
-                        f"      '{name}',",
-                        "      input,",
-                        f"      lambda x: TypeAdapter({input_type}).dump_python(x,",
-                        "        by_alias=True,",
-                        "        exclude_none=True,",
-                        "      ),",
-                        f"     {parse_output_method}",
-                        f"     {parse_error_method}",
-                        "    )",
+                        indent(
+                            dedent(
+                                f"""\
+                    async def {name}(
+                      self,
+                      input: {input_type},
+                    ) -> AsyncIterator[{output_or_error_type}]:
+                      return await self.client.send_subscription(
+                        '{schema_name}',
+                        '{name}',
+                        input,
+                        lambda x: TypeAdapter({input_type})
+                          .dump_python(
+                            x,
+                            by_alias=True,
+                            exclude_none=True,
+                          ),
+                        {parse_output_method}
+                        {parse_error_method}
+                      )
+                      """
+                            ),
+                            "  ",
+                        )
                     ]
                 )
             elif procedure.type == "upload":
@@ -319,92 +338,128 @@ def generate_river_client_module(
                 if init_type:
                     current_chunks.extend(
                         [
-                            f"  async def {name}(",
-                            "    self,",
-                            f"    init: {init_type},",
-                            f"    inputStream: AsyncIterable[{input_type}],",
-                            f"  ) -> {output_type}:",
-                            f"    {control_flow_keyword}await self.client.send_upload(",
-                            f"      '{schema_name}',",
-                            f"      '{name}',",
-                            "      init,",
-                            "      inputStream,",
-                            f"      TypeAdapter({init_type}).validate_python,",
-                            f"      lambda x: TypeAdapter({input_type}).dump_python(x,",
-                            "        by_alias=True,",
-                            "        exclude_none=True,",
-                            "      ),",
-                            f"     {parse_output_method}",
-                            f"     {parse_error_method}",
-                            "    )",
+                            indent(
+                                dedent(
+                                    f"""\
+                        async def {name}(
+                          self,
+                          init: {init_type},
+                          inputStream: AsyncIterable[{input_type}],
+                        ) -> {output_type}:
+                          {control_flow_keyword}await self.client.send_upload(
+                            '{schema_name}',
+                            '{name}',
+                            init,
+                            inputStream,
+                            TypeAdapter({init_type}).validate_python,
+                            lambda x: TypeAdapter({input_type})
+                              .dump_python(
+                                x,
+                                by_alias=True,
+                                exclude_none=True,
+                              ),
+                            {parse_output_method}
+                            {parse_error_method}
+                          )
+                            """
+                                ),
+                                "  ",
+                            )
                         ]
                     )
                 else:
                     current_chunks.extend(
                         [
-                            f"  async def {name}(",
-                            "    self,",
-                            f"    inputStream: AsyncIterable[{input_type}],"
-                            f"  ) -> {output_or_error_type}:",
-                            f"    {control_flow_keyword}await self.client.send_upload(",
-                            f"      '{schema_name}',",
-                            f"      '{name}',",
-                            "     None,",
-                            "     inputStream,",
-                            "     None,",
-                            f"      lambda x: TypeAdapter({input_type}).dump_python(x,",
-                            "        by_alias=True,",
-                            "        exclude_none=True,",
-                            "      ),",
-                            f"     {parse_output_method}",
-                            f"     {parse_error_method}",
-                            "    )",
+                            indent(
+                                dedent(
+                                    f"""\
+                        async def {name}(
+                          self,
+                          inputStream: AsyncIterable[{input_type}],
+                        ) -> {output_or_error_type}:
+                          {control_flow_keyword}await self.client.send_upload(
+                            '{schema_name}',
+                            '{name}',
+                            None,
+                            inputStream,
+                            None,
+                            lambda x: TypeAdapter({input_type})
+                              .dump_python(
+                                x,
+                                by_alias=True,
+                                exclude_none=True,
+                              ),
+                            {parse_output_method}
+                            {parse_error_method}
+                          )
+                            """
+                                ),
+                                "  ",
+                            )
                         ]
                     )
             elif procedure.type == "stream":
                 if init_type:
                     current_chunks.extend(
                         [
-                            f"  async def {name}(",
-                            "    self,",
-                            f"    init: {init_type},",
-                            f"    inputStream: AsyncIterable[{input_type}],",
-                            f"  ) -> AsyncIterator[{output_or_error_type}]:",
-                            "    return await self.client.send_stream(",
-                            f"      '{schema_name}',",
-                            f"      '{name}',",
-                            "      init,",
-                            "      inputStream,",
-                            f"     TypeAdapter({init_type}).validate_python,",
-                            f"      lambda x: TypeAdapter({input_type}).dump_python(x,",
-                            "        by_alias=True,",
-                            "        exclude_none=True,",
-                            "      ),",
-                            f"     {parse_output_method}",
-                            f"     {parse_error_method}",
-                            "    )",
+                            indent(
+                                dedent(
+                                    f"""\
+                        async def {name}(
+                          self,
+                          init: {init_type},
+                          inputStream: AsyncIterable[{input_type}],
+                        ) -> AsyncIterator[{output_or_error_type}]:
+                          return await self.client.send_stream(
+                            '{schema_name}',
+                            '{name}',
+                            init,
+                            inputStream,
+                            TypeAdapter({init_type}).validate_python,
+                            lambda x: TypeAdapter({input_type})
+                              .dump_python(
+                                x,
+                                by_alias=True,
+                                exclude_none=True,
+                              ),
+                            {parse_output_method}
+                            {parse_error_method}
+                          )
+                            """
+                                ),
+                                "  ",
+                            )
                         ]
                     )
                 else:
                     current_chunks.extend(
                         [
-                            f"  async def {name}(",
-                            "    self,",
-                            f"    inputStream: AsyncIterable[{input_type}],",
-                            f") -> AsyncIterator[{output_or_error_type}]:",
-                            "    return await self.client.send_stream(",
-                            f"      '{schema_name}',",
-                            f"      '{name}',",
-                            "      None,",
-                            "      inputStream,",
-                            "      None,",
-                            f"      lambda x: TypeAdapter({input_type}).dump_python(x,",
-                            "        by_alias=True,",
-                            "        exclude_none=True,",
-                            "      ),",
-                            f"     {parse_output_method}",
-                            f"     {parse_error_method}",
-                            "    )",
+                            indent(
+                                dedent(
+                                    f"""\
+                        async def {name}(
+                          self,
+                          inputStream: AsyncIterable[{input_type}],
+                        ) -> AsyncIterator[{output_or_error_type}]:
+                          return await self.client.send_stream(
+                            '{schema_name}',
+                            '{name}',
+                            None,
+                            inputStream,
+                            None,
+                            lambda x: TypeAdapter({input_type})
+                              .dump_python(
+                                x,
+                                by_alias=True,
+                                exclude_none=True,
+                              ),
+                            {parse_output_method}
+                            {parse_error_method}
+                          )
+                            """
+                                ),
+                                "  ",
+                            )
                         ]
                     )
 

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -489,9 +489,11 @@ def schema_to_river_client_codegen(
     with open(schema_path) as f:
         schemas = RiverSchemaFile(json.load(f))
     with open(target_path, "w") as f:
-        f.write(
-            black.format_str(
-                "\n".join(generate_river_client_module(client_name, schemas.root)),
-                mode=black.FileMode(string_normalization=False),
+        s = "\n".join(generate_river_client_module(client_name, schemas.root))
+        try:
+            f.write(
+                black.format_str(s, mode=black.FileMode(string_normalization=False))
             )
-        )
+        except:
+            f.write(s)
+            raise

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -287,7 +287,7 @@ def generate_river_client_module(
                         input,
                         lambda x: TypeAdapter({input_type})
                           .dump_python(
-                            x,
+                            x, # type: ignore[arg-type]
                             by_alias=True,
                             exclude_none=True,
                           ),
@@ -316,7 +316,7 @@ def generate_river_client_module(
                         input,
                         lambda x: TypeAdapter({input_type})
                           .dump_python(
-                            x,
+                            x, # type: ignore[arg-type]
                             by_alias=True,
                             exclude_none=True,
                           ),
@@ -354,7 +354,7 @@ def generate_river_client_module(
                             TypeAdapter({init_type}).validate_python,
                             lambda x: TypeAdapter({input_type})
                               .dump_python(
-                                x,
+                                x, # type: ignore[arg-type]
                                 by_alias=True,
                                 exclude_none=True,
                               ),
@@ -385,7 +385,7 @@ def generate_river_client_module(
                             None,
                             lambda x: TypeAdapter({input_type})
                               .dump_python(
-                                x,
+                                x, # type: ignore[arg-type]
                                 by_alias=True,
                                 exclude_none=True,
                               ),
@@ -418,7 +418,7 @@ def generate_river_client_module(
                             TypeAdapter({init_type}).validate_python,
                             lambda x: TypeAdapter({input_type})
                               .dump_python(
-                                x,
+                                x, # type: ignore[arg-type]
                                 by_alias=True,
                                 exclude_none=True,
                               ),
@@ -449,7 +449,7 @@ def generate_river_client_module(
                             None,
                             lambda x: TypeAdapter({input_type})
                               .dump_python(
-                                x,
+                                x, # type: ignore[arg-type]
                                 by_alias=True,
                                 exclude_none=True,
                               ),

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -246,16 +246,12 @@ def generate_river_client_module(
                 )
                 if error_type == "None":
                     error_type = "RiverError"
-                    output_or_error_type = f"Union[{output_type}, {error_type}]"
-                    error_encoder = f"TypeAdapter({error_type}).validate_python(x)"
                 else:
-                    output_or_error_type = f"Union[{output_type}, {error_type}]"
-                    error_encoder = f"TypeAdapter({error_type}).validate_python(x)"
                     chunks.extend(errors_chunks)
             else:
                 error_type = "RiverError"
-                output_or_error_type = f"Union[{output_type}, {error_type}]"
-                error_encoder = f"TypeAdapter({error_type}).validate_python(x)"
+            output_or_error_type = f"Union[{output_type}, {error_type}]"
+            error_encoder = f"TypeAdapter({error_type}).validate_python(x)"
 
             output_encoder = f"TypeAdapter({output_type}).validate_python(x)"
             if output_type == "None":

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -50,6 +50,14 @@ class RiverSchema(BaseModel):
 RiverSchemaFile = RootModel[Dict[str, RiverSchema]]
 
 
+def reindent(prefix: str, code: str) -> str:
+    """
+    Take an arbitrarily indented code block, dedent to the lowest common
+    indent level and then reindent based on the supplied prefix
+    """
+    return indent(dedent(code), prefix)
+
+
 def encode_type(
     type: RiverType, prefix: str, base_model: str = "BaseModel"
 ) -> Tuple[str, Sequence[str]]:
@@ -278,9 +286,9 @@ def generate_river_client_module(
                     control_flow_keyword = ""
                 current_chunks.extend(
                     [
-                        indent(
-                            dedent(
-                                f"""\
+                        reindent(
+                            "  ",
+                            f"""\
                     async def {name}(
                       self,
                       input: {input_type},
@@ -298,18 +306,16 @@ def generate_river_client_module(
                         {parse_output_method},
                         {parse_error_method},
                       )
-                        """
-                            ),
-                            "  ",
+                        """,
                         )
                     ]
                 )
             elif procedure.type == "subscription":
                 current_chunks.extend(
                     [
-                        indent(
-                            dedent(
-                                f"""\
+                        reindent(
+                            "  ",
+                            f"""\
                     async def {name}(
                       self,
                       input: {input_type},
@@ -327,9 +333,7 @@ def generate_river_client_module(
                         {parse_output_method},
                         {parse_error_method},
                       )
-                      """
-                            ),
-                            "  ",
+                      """,
                         )
                     ]
                 )
@@ -340,9 +344,9 @@ def generate_river_client_module(
                 if init_type:
                     current_chunks.extend(
                         [
-                            indent(
-                                dedent(
-                                    f"""\
+                            reindent(
+                                "  ",
+                                f"""\
                         async def {name}(
                           self,
                           init: {init_type},
@@ -363,18 +367,16 @@ def generate_river_client_module(
                             {parse_output_method},
                             {parse_error_method},
                           )
-                            """
-                                ),
-                                "  ",
+                            """,
                             )
                         ]
                     )
                 else:
                     current_chunks.extend(
                         [
-                            indent(
-                                dedent(
-                                    f"""\
+                            reindent(
+                                "  ",
+                                f"""\
                         async def {name}(
                           self,
                           inputStream: AsyncIterable[{input_type}],
@@ -394,9 +396,7 @@ def generate_river_client_module(
                             {parse_output_method},
                             {parse_error_method},
                           )
-                            """
-                                ),
-                                "  ",
+                            """,
                             )
                         ]
                     )
@@ -404,9 +404,9 @@ def generate_river_client_module(
                 if init_type:
                     current_chunks.extend(
                         [
-                            indent(
-                                dedent(
-                                    f"""\
+                            reindent(
+                                "  ",
+                                f"""\
                         async def {name}(
                           self,
                           init: {init_type},
@@ -427,18 +427,16 @@ def generate_river_client_module(
                             {parse_output_method},
                             {parse_error_method},
                           )
-                            """
-                                ),
-                                "  ",
+                            """,
                             )
                         ]
                     )
                 else:
                     current_chunks.extend(
                         [
-                            indent(
-                                dedent(
-                                    f"""\
+                            reindent(
+                                "  ",
+                                f"""\
                         async def {name}(
                           self,
                           inputStream: AsyncIterable[{input_type}],
@@ -458,9 +456,7 @@ def generate_river_client_module(
                             {parse_output_method},
                             {parse_error_method},
                           )
-                            """
-                                ),
-                                "  ",
+                            """,
                             )
                         ]
                     )

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union
 
 import black
 from pydantic import BaseModel, Field, RootModel
@@ -36,7 +36,9 @@ class RiverProcedure(BaseModel):
     input: RiverType
     output: RiverType
     errors: Optional[RiverType] = Field(default=None)
-    type: str
+    type: (
+        Literal["rpc"] | Literal["stream"] | Literal["subscription"] | Literal["upload"]
+    )
 
 
 class RiverSchema(BaseModel):

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -39,6 +39,7 @@ class RiverProcedure(BaseModel):
     type: (
         Literal["rpc"] | Literal["stream"] | Literal["subscription"] | Literal["upload"]
     )
+    description: Optional[str] = Field(default=None)
 
 
 class RiverSchema(BaseModel):


### PR DESCRIPTION
Why
===

Any place we might encounter a `Union[...]`, we need `# type: ignore[arg-type]` to avoid mypy failing to typecheck, due to https://github.com/pydantic/pydantic/pull/8923, acknowledging that while pyright seems to have good inference, mypy fails to typecheck.

To better understand the issue and determine if there were any workarounds, I created https://github.com/blast-hardcheese/mypy-union-bug with the intent to report upstream, before finding the ongoing discussion threads linked here and in comments.

What changed
============

### Main

- Reflow format strings to use multiline format strings and `indent(dedent(s, ...))`. This gives us more horizontal space instead of trying to use C-style line continuation to avoid the 88-character limit
- Adding `# type: ignore[arg-type]` to possible `Union` slots

### 🧹 
- Tracking type literals more closely
- Reducing nested format strings for clarity
- Bubble up string-formatted comma for intelligibility

Test plan
=========

Manually running against production schemas, gathering sources together for a sensible local test suite for codegen