### PR TITLE
Revert "Make client accept a function for websocket uri and hadnshakemetadata (#62)

### DIFF
--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -1,6 +1,6 @@
 import logging
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
-from typing import Any, Optional, Union
+from collections.abc import AsyncIterable, AsyncIterator
+from typing import Any, Callable, Optional, Union
 
 from replit_river.client_transport import ClientTransport
 from replit_river.transport_options import TransportOptions
@@ -16,23 +16,22 @@ logger = logging.getLogger(__name__)
 
 
 class Client:
-
     def __init__(
         self,
-        websocket_uri_factory: Callable[[], Awaitable[str]],
+        websocket_uri: str,
         client_id: str,
         server_id: str,
         transport_options: TransportOptions,
-        handshake_metadata_factory: Optional[Callable[[], Awaitable[Any]]] = None,
+        handshake_metadata: Optional[Any] = None,
     ) -> None:
         self._client_id = client_id
         self._server_id = server_id
         self._transport = ClientTransport(
-            websocket_uri_factory=websocket_uri_factory,
+            websocket_uri=websocket_uri,
             client_id=client_id,
             server_id=server_id,
             transport_options=transport_options,
-            handshake_metadata_factory=handshake_metadata_factory,
+            handshake_metadata=handshake_metadata,
         )
 
     async def close(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,14 +137,10 @@ async def client(
     transport_options: TransportOptions,
     no_logging_error: NoErrors,
 ) -> AsyncGenerator[Client, None]:
-
-    async def websocket_uri_factory() -> str:
-        return "ws://localhost:8765"
-
     try:
         async with serve(server.serve, "localhost", 8765):
             client = Client(
-                websocket_uri_factory,
+                "ws://localhost:8765",
                 client_id="test_client",
                 server_id="test_server",
                 transport_options=transport_options,


### PR DESCRIPTION
Why
===

This reverts commit 71ba3dfb033db0180a2f6bc8f286e62ea542b047. We've been seeing some issues attempting to negotiate tokens successfully, this seems like it is most likely to be the cause.

What changed
============

Reverting async metadata for now

Test plan
=========

Does @airportyh's manual testing pass again?