### PR TITLE
Reapply "Make client accept a function for websocket uri and hadnshakemetadata (#62) (#71)

### DIFF
--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import AsyncIterable, AsyncIterator
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable
 from typing import Any, Callable, Generic, Optional, TypeVar, Union
 
 from replit_river.client_transport import ClientTransport
@@ -21,20 +21,22 @@ HandshakeType = TypeVar("HandshakeType")
 class Client(Generic[HandshakeType]):
     def __init__(
         self,
-        websocket_uri: str,
+        websocket_uri_factory: Callable[[], Awaitable[str]],
         client_id: str,
         server_id: str,
         transport_options: TransportOptions,
-        handshake_metadata: Optional[HandshakeType] = None,
+        handshake_metadata_factory: Optional[
+            Callable[[], Awaitable[HandshakeType]]
+        ] = None,
     ) -> None:
         self._client_id = client_id
         self._server_id = server_id
         self._transport = ClientTransport[HandshakeType](
-            websocket_uri=websocket_uri,
+            websocket_uri_factory=websocket_uri_factory,
             client_id=client_id,
             server_id=server_id,
             transport_options=transport_options,
-            handshake_metadata=handshake_metadata,
+            handshake_metadata_factory=handshake_metadata_factory,
         )
 
     async def close(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,10 +137,14 @@ async def client(
     transport_options: TransportOptions,
     no_logging_error: NoErrors,
 ) -> AsyncGenerator[Client, None]:
+
+    async def websocket_uri_factory() -> str:
+        return "ws://localhost:8765"
+
     try:
         async with serve(server.serve, "localhost", 8765):
             client: Client[NoReturn] = Client(
-                "ws://localhost:8765",
+                websocket_uri_factory,
                 client_id="test_client",
                 server_id="test_server",
                 transport_options=transport_options,


### PR DESCRIPTION
Why
===

We want this, but there were issues before. Hopefully the types disambiguate enough to help us over the hump.

What changed
============

Reland the previous changeset

Test plan
=========

Can we deploy without causing trouble?