### PR TITLE
Add RiverServiceException

### DIFF
--- a/replit_river/client_session.py
+++ b/replit_river/client_session.py
@@ -6,7 +6,7 @@ import nanoid  # type: ignore
 from aiochannel import Channel
 from aiochannel.errors import ChannelClosed
 
-from replit_river.error_schema import ERROR_CODE_STREAM_CLOSED, RiverException, RiverServiceException
+from replit_river.error_schema import ERROR_CODE_STREAM_CLOSED, RiverException, exception_from_message
 from replit_river.session import Session
 from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE
 
@@ -51,7 +51,7 @@ class ClientSession(Session):
             try:
                 response = await output.get()
             except ChannelClosed as e:
-                raise RiverServiceException(
+                raise exception_from_message(error.code)(
                     ERROR_CODE_STREAM_CLOSED,
                     "Stream closed before response",
                     service_name,
@@ -64,7 +64,7 @@ class ClientSession(Session):
                     error = error_deserializer(response["payload"])
                 except Exception as e:
                     raise RiverException("error_deserializer", str(e)) from e
-                raise RiverServiceException(
+                raise exception_from_message(error.code)(
                     error.code,
                     error.message,
                     service_name,
@@ -121,7 +121,7 @@ class ClientSession(Session):
                     payload=request_serializer(item),
                 )
         except Exception as e:
-            raise RiverServiceException(
+            raise exception_from_message(error.code)(
                     ERROR_CODE_STREAM_CLOSED,
                     str(e),
                     service_name,
@@ -140,7 +140,7 @@ class ClientSession(Session):
             try:
                 response = await output.get()
             except ChannelClosed as e:
-                raise RiverServiceException(
+                raise exception_from_message(error.code)(
                         ERROR_CODE_STREAM_CLOSED,
                         "Stream closed before response",
                         service_name,
@@ -200,7 +200,7 @@ class ClientSession(Session):
                     continue
                 yield response_deserializer(item["payload"])
         except (RuntimeError, ChannelClosed) as e:
-            raise RiverServiceException(
+            raise exception_from_message(error.code)(
                 ERROR_CODE_STREAM_CLOSED,
                 "Stream closed before response",
                 service_name,
@@ -254,7 +254,7 @@ class ClientSession(Session):
             empty_stream = True
 
         except Exception as e:
-            raise RiverServiceException(
+            raise exception_from_message(error.code)(
                 ERROR_CODE_STREAM_CLOSED,
                 str(e),
                 service_name,
@@ -301,7 +301,7 @@ class ClientSession(Session):
                     continue
                 yield response_deserializer(item["payload"])
         except (RuntimeError, ChannelClosed) as e:
-            raise RiverServiceException(
+            raise exception_from_message(error.code)(
                 ERROR_CODE_STREAM_CLOSED,
                 "Stream closed before response",
                 service_name,

--- a/replit_river/client_session.py
+++ b/replit_river/client_session.py
@@ -9,9 +9,9 @@ from aiochannel.errors import ChannelClosed
 from replit_river.error_schema import (
     ERROR_CODE_STREAM_CLOSED,
     RiverException,
-    exception_from_message,
     RiverServiceException,
     StreamClosedRiverServiceException,
+    exception_from_message,
 )
 from replit_river.session import Session
 from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE

--- a/replit_river/client_session.py
+++ b/replit_river/client_session.py
@@ -6,7 +6,13 @@ import nanoid  # type: ignore
 from aiochannel import Channel
 from aiochannel.errors import ChannelClosed
 
-from replit_river.error_schema import ERROR_CODE_STREAM_CLOSED, RiverException, exception_from_message
+from replit_river.error_schema import (
+    ERROR_CODE_STREAM_CLOSED,
+    RiverException,
+    exception_from_message,
+    RiverServiceException,
+    StreamClosedRiverServiceException,
+)
 from replit_river.session import Session
 from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE
 
@@ -51,11 +57,11 @@ class ClientSession(Session):
             try:
                 response = await output.get()
             except ChannelClosed as e:
-                raise exception_from_message(error.code)(
+                raise RiverServiceException(
                     ERROR_CODE_STREAM_CLOSED,
                     "Stream closed before response",
                     service_name,
-                    procedure_name
+                    procedure_name,
                 ) from e
             except RuntimeError as e:
                 raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e)) from e
@@ -65,10 +71,7 @@ class ClientSession(Session):
                 except Exception as e:
                     raise RiverException("error_deserializer", str(e)) from e
                 raise exception_from_message(error.code)(
-                    error.code,
-                    error.message,
-                    service_name,
-                    procedure_name
+                    error.code, error.message, service_name, procedure_name
                 )
             return response_deserializer(response["payload"])
         except RiverException as e:
@@ -121,11 +124,8 @@ class ClientSession(Session):
                     payload=request_serializer(item),
                 )
         except Exception as e:
-            raise exception_from_message(error.code)(
-                    ERROR_CODE_STREAM_CLOSED,
-                    str(e),
-                    service_name,
-                    procedure_name
+            raise RiverServiceException(
+                ERROR_CODE_STREAM_CLOSED, str(e), service_name, procedure_name
             ) from e
         await self.send_close_stream(
             service_name,
@@ -140,11 +140,11 @@ class ClientSession(Session):
             try:
                 response = await output.get()
             except ChannelClosed as e:
-                raise exception_from_message(error.code)(
-                        ERROR_CODE_STREAM_CLOSED,
-                        "Stream closed before response",
-                        service_name,
-                        procedure_name
+                raise RiverServiceException(
+                    ERROR_CODE_STREAM_CLOSED,
+                    "Stream closed before response",
+                    service_name,
+                    procedure_name,
                 ) from e
             except RuntimeError as e:
                 raise RiverException(ERROR_CODE_STREAM_CLOSED, str(e)) from e
@@ -153,7 +153,9 @@ class ClientSession(Session):
                     error = error_deserializer(response["payload"])
                 except Exception as e:
                     raise RiverException("error_deserializer", str(e)) from e
-                raise RiverException(error.code, error.message)
+                raise exception_from_message(error.code)(
+                    error.code, error.message, service_name, procedure_name
+                )
 
             return response_deserializer(response["payload"])
         except RiverException as e:
@@ -200,11 +202,11 @@ class ClientSession(Session):
                     continue
                 yield response_deserializer(item["payload"])
         except (RuntimeError, ChannelClosed) as e:
-            raise exception_from_message(error.code)(
+            raise RiverServiceException(
                 ERROR_CODE_STREAM_CLOSED,
                 "Stream closed before response",
                 service_name,
-                procedure_name
+                procedure_name,
             ) from e
         except Exception as e:
             raise e
@@ -254,11 +256,8 @@ class ClientSession(Session):
             empty_stream = True
 
         except Exception as e:
-            raise exception_from_message(error.code)(
-                ERROR_CODE_STREAM_CLOSED,
-                str(e),
-                service_name,
-                procedure_name
+            raise StreamClosedRiverServiceException(
+                ERROR_CODE_STREAM_CLOSED, str(e), service_name, procedure_name
             ) from e
 
         # Create the encoder task
@@ -301,11 +300,11 @@ class ClientSession(Session):
                     continue
                 yield response_deserializer(item["payload"])
         except (RuntimeError, ChannelClosed) as e:
-            raise exception_from_message(error.code)(
+            raise RiverServiceException(
                 ERROR_CODE_STREAM_CLOSED,
                 "Stream closed before response",
                 service_name,
-                procedure_name
+                procedure_name,
             ) from e
         except Exception as e:
             raise e

--- a/replit_river/error_schema.py
+++ b/replit_river/error_schema.py
@@ -7,6 +7,16 @@ ERROR_HANDSHAKE = "handshake_failed"
 ERROR_SESSION = "session_error"
 
 
+# UNCAUGHT_ERROR_ERROR_CODE is the code that is used when an error is thrown
+# inside a procedure handler that's not required.
+UNCAUGHT_ERROR_ERROR_CODE = 'UNCAUGHT_ERROR'
+
+# INVALID_REQUEST_ERROR_CODE is the code used when a client's request is invalid.
+INVALID_REQUEST_ERROR_CODE = 'INVALID_REQUEST'
+
+# CANCEL_ERROR_CODE is the code used when either server or client cancels the stream.
+CANCEL_ERROR_CODE = 'CANCEL'
+
 class RiverError(BaseModel):
     """Error message from the server."""
 
@@ -43,6 +53,23 @@ class RiverServiceException(RiverException):
             f"code: {code}, message: {message}"
         )
         super().__init__(msg)
+
+class StreamClosedRiverServiceException(RiverException):
+    pass
+class HandshakeErrorRiverServiceException(RiverException):
+    pass
+class SessionErrorRiverServiceException(RiverException):
+    pass
+
+def exception_from_message(code: str) -> type[RiverServiceException]:
+    """Return the error class for a given error code."""
+    if code == ERROR_CODE_STREAM_CLOSED:
+        return StreamClosedRiverServiceException
+    if code == ERROR_HANDSHAKE:
+        return HandshakeErrorRiverServiceException
+    if code == ERROR_SESSION:
+        return SessionErrorRiverServiceException
+    return RiverServiceException
 
 def stringify_exception(e: BaseException, limit: int = 10) -> str:
     """Return a string representation of an Exception.

--- a/replit_river/error_schema.py
+++ b/replit_river/error_schema.py
@@ -7,15 +7,16 @@ ERROR_HANDSHAKE = "handshake_failed"
 ERROR_SESSION = "session_error"
 
 
-# UNCAUGHT_ERROR_ERROR_CODE is the code that is used when an error is thrown
+# ERROR_CODE_UNCAUGHT_ERROR is the code that is used when an error is thrown
 # inside a procedure handler that's not required.
-UNCAUGHT_ERROR_ERROR_CODE = 'UNCAUGHT_ERROR'
+ERROR_CODE_UNCAUGHT_ERROR = "UNCAUGHT_ERROR"
 
-# INVALID_REQUEST_ERROR_CODE is the code used when a client's request is invalid.
-INVALID_REQUEST_ERROR_CODE = 'INVALID_REQUEST'
+# ERROR_CODE_INVALID_REQUEST is the code used when a client's request is invalid.
+ERROR_CODE_INVALID_REQUEST = "INVALID_REQUEST"
 
-# CANCEL_ERROR_CODE is the code used when either server or client cancels the stream.
-CANCEL_ERROR_CODE = 'CANCEL'
+# ERROR_CODE_CANCEL is the code used when either server or client cancels the stream.
+ERROR_CODE_CANCEL = "CANCEL"
+
 
 class RiverError(BaseModel):
     """Error message from the server."""
@@ -32,16 +33,13 @@ class RiverException(Exception):
         self.message = message
         super().__init__(f"Error in river, code: {code}, message: {message}")
 
+
 class RiverServiceException(RiverException):
     """Exception raised by river as a result of a fault in the service running river."""
 
     def __init__(
-            self,
-            code: str,
-            message: str,
-            service: Optional[str],
-            procedure: Optional[str]
-        ) -> None:
+        self, code: str, message: str, service: Optional[str], procedure: Optional[str]
+    ) -> None:
         self.code = code
         self.message = message
         self.service = service
@@ -52,24 +50,37 @@ class RiverServiceException(RiverException):
             f"Error in river service ({service} - {procedure}), "
             f"code: {code}, message: {message}"
         )
-        super().__init__(msg)
+        super().__init__(code, msg)
 
-class StreamClosedRiverServiceException(RiverException):
+
+class UncaughtErrorRiverServiceException(RiverServiceException):
     pass
-class HandshakeErrorRiverServiceException(RiverException):
+
+
+class InvalidRequestRiverServiceException(RiverServiceException):
     pass
-class SessionErrorRiverServiceException(RiverException):
+
+
+class CancelRiverServiceException(RiverServiceException):
     pass
+
+
+class StreamClosedRiverServiceException(RiverServiceException):
+    pass
+
 
 def exception_from_message(code: str) -> type[RiverServiceException]:
     """Return the error class for a given error code."""
     if code == ERROR_CODE_STREAM_CLOSED:
         return StreamClosedRiverServiceException
-    if code == ERROR_HANDSHAKE:
-        return HandshakeErrorRiverServiceException
-    if code == ERROR_SESSION:
-        return SessionErrorRiverServiceException
+    elif code == ERROR_CODE_UNCAUGHT_ERROR:
+        return UncaughtErrorRiverServiceException
+    elif code == ERROR_CODE_INVALID_REQUEST:
+        return InvalidRequestRiverServiceException
+    elif code == ERROR_CODE_CANCEL:
+        return CancelRiverServiceException
     return RiverServiceException
+
 
 def stringify_exception(e: BaseException, limit: int = 10) -> str:
     """Return a string representation of an Exception.

--- a/replit_river/error_schema.py
+++ b/replit_river/error_schema.py
@@ -22,6 +22,27 @@ class RiverException(Exception):
         self.message = message
         super().__init__(f"Error in river, code: {code}, message: {message}")
 
+class RiverServiceException(RiverException):
+    """Exception raised by river as a result of a fault in the service running river."""
+
+    def __init__(
+            self,
+            code: str,
+            message: str,
+            service: Optional[str],
+            procedure: Optional[str]
+        ) -> None:
+        self.code = code
+        self.message = message
+        self.service = service
+        self.procedure = procedure
+        service = service or "N/A"
+        procedure = procedure or "N/A"
+        msg = (
+            f"Error in river service ({service} - {procedure}), "
+            f"code: {code}, message: {message}"
+        )
+        super().__init__(msg)
 
 def stringify_exception(e: BaseException, limit: int = 10) -> str:
     """Return a string representation of an Exception.


### PR DESCRIPTION
Why
===

Sometimes River has an issue, sometimes the service running River has an issue. We should split those out so that people know which is which.
 
What changed
============

Added `RiverServiceException` to differentiate the two. `RiverServiceException` also includes extra fields to include the service and procedure.

Test plan
=========

CI/CD, this change is backwards compatible due to RiverServiceException being a subclass of RiverException.