### PR TITLE
Configure handshake timeout separately from session disconnect grace period

### DIFF
--- a/replit_river/server.py
+++ b/replit_river/server.py
@@ -69,10 +69,11 @@ class Server(object):
         logger.debug(
             "River server started establishing session with ws: %s", websocket.id
         )
-        grace_ms = self._transport_options.session_disconnect_grace_ms / 1000
+        grace_ms = self._transport_options.handshake_timeout_ms
         try:
             session = await asyncio.wait_for(
-                self._handshake_to_get_session(websocket), grace_ms
+                self._handshake_to_get_session(websocket),
+                grace_ms / 1000,  # wait_for unit is seconds
             )
             if not session:
                 return

--- a/replit_river/transport_options.py
+++ b/replit_river/transport_options.py
@@ -19,6 +19,7 @@ class ConnectionRetryOptions(BaseModel):
 # setup in replit web can be found at
 # https://github.com/replit/repl-it-web/blob/main/pkg/pid2/src/entrypoints/protocol.ts#L13
 class TransportOptions(BaseModel):
+    handshake_timeout_ms: float = 10_000
     session_disconnect_grace_ms: float = 10_000
     heartbeat_ms: float = 2_500
     # TODO: This should have a better name like max_failed_heartbeats
@@ -37,12 +38,14 @@ class TransportOptions(BaseModel):
 
     @classmethod
     def create_from_env(cls) -> "TransportOptions":
+        handshake_timeout_ms = float(os.getenv("HANDSHAKE_TIMEOUT_MS", 5_000))
         session_disconnect_grace_ms = float(
             os.getenv("SESSION_DISCONNECT_GRACE_MS", 5_000)
         )
-        heartbeat_ms = float(os.getenv("HEARTBEAT_MS", 2000))
+        heartbeat_ms = float(os.getenv("HEARTBEAT_MS", 2_000))
         heartbeats_to_dead = int(os.getenv("HEARTBEATS_UNTIL_DEAD", 2))
         return TransportOptions(
+            handshake_timeout_ms=handshake_timeout_ms,
             session_disconnect_grace_ms=session_disconnect_grace_ms,
             heartbeat_ms=heartbeat_ms,
             heartbeats_until_dead=heartbeats_to_dead,

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -1,0 +1,26 @@
+from time import time
+
+import pytest
+import websockets
+from websockets.exceptions import ConnectionClosedOK
+from websockets.server import serve
+
+from replit_river.server import Server
+from replit_river.transport_options import TransportOptions
+
+
+@pytest.fixture
+def transport_options() -> TransportOptions:
+    return TransportOptions(handshake_timeout_ms=200)
+
+
+@pytest.mark.asyncio
+async def test_handshake_timeout(server: Server) -> None:
+    async with serve(server.serve, "localhost", 8765):
+        start = time()
+        ws = await websockets.connect("ws://localhost:8765")
+        with pytest.raises(ConnectionClosedOK):
+            await ws.recv()
+        diff = time() - start
+        # we should wait at least 200ms but not for too long
+        assert diff > 0.2 and diff < 1.0


### PR DESCRIPTION
Why
===

~We were magically computing a handshake timeout by dividing the session disconnect by 1000, which in production lead to a handshake timeout of 15ms (as session disconnect grace period is set to 15sec), which is pretty optimistic since RTT can be on the order of 100s of ms sometimes.~

Instead of computing this magically, let's allow it be configured explicitly and set it to a default of 10s which matches what we have set in repl-it-web.

What changed
============

- Add `handshake_timeout_ms` config with a default of 10s

Test plan
=========

- Ideally we see less handshake timeout errors in prod

