### PR TITLE
bug/conditionally enable typeddicts

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -355,6 +355,14 @@ def encode_type(
                                 typeddict_encoder.append(
                                     f"if x['{safe_name}'] else None"
                                 )
+                        elif prop.type == "array":
+                            assert type_name.startswith(
+                                "List["
+                            )  # in case we change to list[...]
+                            _inner_type_name = type_name[len("List[") : -len("]")]
+                            typeddict_encoder.append(
+                                f"[encode_{_inner_type_name}(y) for y in x['{name}']]"
+                            )
                         else:
                             typeddict_encoder.append(f"x['{safe_name}']")
 

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -66,7 +66,7 @@ class RiverService(BaseModel):
 
 class RiverSchema(BaseModel):
     services: Dict[str, RiverService]
-    handshakeSchema: Optional[RiverConcreteType]
+    handshakeSchema: Optional[RiverConcreteType] = Field(default=None)
 
 
 RiverSchemaFile = RootModel[RiverSchema]

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -304,11 +304,11 @@ def encode_type(
             typeddict_encoder.append("None")
             return ("None", ())
         if type.type == "Date":
-            # typeddict_encoder.append("TODO")
+            typeddict_encoder.append("TODO: dstewart")
             return ("datetime.datetime", ())
         if type.type == "array" and type.items:
             type_name, type_chunks = encode_type(type.items, prefix, base_model)
-            # typeddict_encoder.append("TODO")
+            typeddict_encoder.append("TODO: dstewart")
             return (f"List[{type_name}]", type_chunks)
         if (
             type.type == "object"

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -380,9 +380,11 @@ def encode_type(
                     if name not in type.required:
                         value = ""
                         if base_model != "TypedDict":
-                            value = (
-                                f" = Field({field_value}, alias='{name}', default=None)"
-                            )
+                            args = f"alias='{name}', default=None"
+                            if field_value != "...":
+                                value = f" = Field({field_value}, {args})"
+                            else:
+                                value = f" = Field({args})"
                         current_chunks.append(f"  kind: Optional[{type_name}]{value}")
                     else:
                         value = ""

--- a/replit_river/codegen/run.py
+++ b/replit_river/codegen/run.py
@@ -27,6 +27,12 @@ def main() -> None:
     )
     client.add_argument("--output", help="output file", required=True)
     client.add_argument("--client-name", help="name of the class", required=True)
+    client.add_argument(
+        "--typed-dict-inputs",
+        help="Enable typed dicts",
+        action="store_true",
+        default=False,
+    )
     client.add_argument("schema", help="schema file")
     args = parser.parse_args()
 
@@ -41,6 +47,8 @@ def main() -> None:
     elif args.command == "client":
         schema_path = os.path.abspath(args.schema)
         target_path = os.path.abspath(args.output)
-        schema_to_river_client_codegen(schema_path, target_path, args.client_name)
+        schema_to_river_client_codegen(
+            schema_path, target_path, args.client_name, args.typed_dict_inputs
+        )
     else:
         raise NotImplementedError(f"Unknown command {args.command}")


### PR DESCRIPTION
Why
===

Unfortunately switching over to `TypedDicts` turned out to be overly optimistic without any sort of test suite to keep things in parity. For now, I'll make the codegen require explicit opt-in to not break clients.

What changed
============

- Conditionally opt-in to TypedDict inputs
- Bugfix: Encode arrays using the inner encoder
- Optional `Field(...`'s are invalid in pydantic, special case that.

Test plan
=========

Manual testing for now