### PR TITLE
Reintroduce previous input encoder

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -520,7 +520,17 @@ def generate_river_client_module(
                                     )
                 """.rstrip()
 
-            render_input_method = f"encode_{input_type}"
+            if typed_dict_inputs:
+                render_input_method = f"encode_{input_type}"
+            else:
+                render_input_method = f"""\
+                                lambda x: TypeAdapter({input_type})
+                                  .dump_python(
+                                    x, # type: ignore[arg-type]
+                                    by_alias=True,
+                                    exclude_none=True,
+                                  )
+                """.rstrip()
             if (
                 isinstance(procedure.input, RiverConcreteType)
                 and procedure.input.type != "object"


### PR DESCRIPTION
Why
===

Follow-on to #78, but this looks like the last change that needed to be gated.

What changed
============

Instead of testing if `base_model == 'TypedDict'`, we need to rely on the boolean that sets that into motion.

Test plan
=========

Manually run this codegen against production specs and verified no changes from the 0.4.0 release