### PR TITLE
clear session if the session is closed to avoid using closed sessions

### DIFF
--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -112,7 +112,7 @@ class ClientTransport(Transport, Generic[HandshakeType]):
             rate_limit.consume_budget(client_id)
 
             # if the session is closed, we shouldn't use it
-            if not old_session or not await old_session.is_session_open():
+            if old_session and not await old_session.is_session_open():
                 old_session = None
 
             try:
@@ -340,6 +340,7 @@ class ClientTransport(Transport, Generic[HandshakeType]):
 
             raise RiverException(
                 ERROR_HANDSHAKE,
-                f"Handshake failed with code ${handshake_response.status.code}: {handshake_response.status.reason}",
+                f"Handshake failed with code ${handshake_response.status.code}: "
+                + f"{handshake_response.status.reason}",
             )
         return handshake_request, handshake_response

--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -124,7 +124,7 @@ class Session(object):
         if self._close_session_after_time_secs is not None:
             # already in grace period, no need to set again
             return
-        logger.debug(
+        logger.info(
             "websocket closed from %s to %s begin grace period",
             self._transport_id,
             self._to_id,
@@ -133,6 +133,7 @@ class Session(object):
 
     async def serve(self) -> None:
         """Serve messages from the websocket."""
+        self._reset_session_close_countdown()
         try:
             async with asyncio.TaskGroup() as tg:
                 try:
@@ -226,7 +227,6 @@ class Session(object):
             old_wrapper = self._ws_wrapper
             old_ws_id = old_wrapper.ws.id
             if new_ws.id != old_ws_id:
-                self._reset_session_close_countdown()
                 await old_wrapper.close()
             self._ws_wrapper = WebsocketWrapper(new_ws)
         await self._send_buffered_messages(new_ws)


### PR DESCRIPTION
Why
===

when we get a `SESSION_STATE_MISMATCH`, we close the old session and delete it, but the recreate fn still has a handle to it

_Describe what prompted you to make this change, link relevant resources: Linear issues, Slack discussions, etc._

What changed
============

if the retry loop detects the old session to be closed, stop using it

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
