### PR TITLE
Make client accept a function for websocket uri and hadnshakemetadata  (try 2)

### DIFF
--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -25,7 +25,7 @@ class Client(Generic[HandshakeType]):
         client_id: str,
         server_id: str,
         transport_options: TransportOptions,
-        handshake_metadata_factory: Optional[Callable[[], Awaitable[Any]]] = None,
+        handshake_metadata_factory: Callable[[], Awaitable[HandshakeType]],
     ) -> None:
         self._client_id = client_id
         self._server_id = server_id

--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -1,6 +1,6 @@
 import logging
-from collections.abc import AsyncIterable, AsyncIterator
-from typing import Any, Callable, Generic, Optional, TypeVar, Union
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from replit_river.client_transport import ClientTransport
 from replit_river.transport_options import TransportOptions
@@ -21,20 +21,20 @@ HandshakeType = TypeVar("HandshakeType")
 class Client(Generic[HandshakeType]):
     def __init__(
         self,
-        websocket_uri: str,
+        websocket_uri_factory: Callable[[], Awaitable[str]],
         client_id: str,
         server_id: str,
         transport_options: TransportOptions,
-        handshake_metadata: HandshakeType,
+        handshake_metadata_factory: Optional[Callable[[], Awaitable[Any]]] = None,
     ) -> None:
         self._client_id = client_id
         self._server_id = server_id
         self._transport = ClientTransport[HandshakeType](
-            websocket_uri=websocket_uri,
+            websocket_uri_factory=websocket_uri_factory,
             client_id=client_id,
             server_id=server_id,
             transport_options=transport_options,
-            handshake_metadata=handshake_metadata,
+            handshake_metadata_factory=handshake_metadata_factory,
         )
 
     async def close(self) -> None:

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -52,7 +52,7 @@ class ClientTransport(Transport, Generic[HandshakeType]):
         client_id: str,
         server_id: str,
         transport_options: TransportOptions,
-        handshake_metadata_factory: Optional[Callable[[], Awaitable[HandshakeType]]],
+        handshake_metadata_factory: Callable[[], Awaitable[HandshakeType]],
     ):
         super().__init__(
             transport_id=client_id,
@@ -125,9 +125,7 @@ class ClientTransport(Transport, Generic[HandshakeType]):
                     else old_session.session_id
                 )
 
-                handshake_metadata = None
-                if self._handshake_metadata_factory is not None:
-                    handshake_metadata = await self._handshake_metadata_factory()
+                handshake_metadata = await self._handshake_metadata_factory()
 
                 try:
                     (

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Generic, Optional, Tuple, TypeVar
 
 import websockets
@@ -47,24 +48,24 @@ HandshakeType = TypeVar("HandshakeType")
 class ClientTransport(Transport, Generic[HandshakeType]):
     def __init__(
         self,
-        websocket_uri: str,
+        websocket_uri_factory: Callable[[], Awaitable[str]],
         client_id: str,
         server_id: str,
         transport_options: TransportOptions,
-        handshake_metadata: HandshakeType,
+        handshake_metadata_factory: Optional[Callable[[], Awaitable[HandshakeType]]],
     ):
         super().__init__(
             transport_id=client_id,
             transport_options=transport_options,
             is_server=False,
         )
-        self._websocket_uri = websocket_uri
+        self._websocket_uri_factory = websocket_uri_factory
         self._client_id = client_id
         self._server_id = server_id
         self._rate_limiter = LeakyBucketRateLimit(
             transport_options.connection_retry_options
         )
-        self._handshake_metadata = handshake_metadata
+        self._handshake_metadata_factory = handshake_metadata_factory
         # We want to make sure there's only one session creation at a time
         self._create_session_lock = asyncio.Lock()
 
@@ -116,12 +117,18 @@ class ClientTransport(Transport, Generic[HandshakeType]):
                 old_session = None
 
             try:
-                ws = await websockets.connect(self._websocket_uri)
+                websocket_uri = await self._websocket_uri_factory()
+                ws = await websockets.connect(websocket_uri)
                 session_id = (
                     self.generate_session_id()
                     if not old_session
                     else old_session.session_id
                 )
+
+                handshake_metadata = None
+                if self._handshake_metadata_factory is not None:
+                    handshake_metadata = await self._handshake_metadata_factory()
+
                 try:
                     (
                         handshake_request,
@@ -130,7 +137,7 @@ class ClientTransport(Transport, Generic[HandshakeType]):
                         self._transport_id,
                         self._server_id,
                         session_id,
-                        self._handshake_metadata,
+                        handshake_metadata,
                         ws,
                         old_session,
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,10 +137,14 @@ async def client(
     transport_options: TransportOptions,
     no_logging_error: NoErrors,
 ) -> AsyncGenerator[Client, None]:
+
+    async def websocket_uri_factory() -> str:
+        return "ws://localhost:8765"
+
     try:
         async with serve(server.serve, "localhost", 8765):
             client: Client[Literal[None]] = Client(
-                "ws://localhost:8765",
+                websocket_uri_factory,
                 client_id="test_client",
                 server_id="test_server",
                 transport_options=transport_options,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,9 @@ async def client(
     async def websocket_uri_factory() -> str:
         return "ws://localhost:8765"
 
+    async def handshake_metadata_factory() -> None:
+        return None
+
     try:
         async with serve(server.serve, "localhost", 8765):
             client: Client[Literal[None]] = Client(
@@ -148,7 +151,7 @@ async def client(
                 client_id="test_client",
                 server_id="test_server",
                 transport_options=transport_options,
-                handshake_metadata=None,
+                handshake_metadata_factory=handshake_metadata_factory
             )
             try:
                 yield client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,7 +151,7 @@ async def client(
                 client_id="test_client",
                 server_id="test_server",
                 transport_options=transport_options,
-                handshake_metadata_factory=handshake_metadata_factory
+                handshake_metadata_factory=handshake_metadata_factory,
             )
             try:
                 yield client


### PR DESCRIPTION
Why
===

We're seeing stale tokens as part of the connection to pid2, we have no way of regenerating the token

What changed
============

Make client accept a function for websocket uri and hadnshake metadata

Test plan
=========

Updated tests, unfortunately no comprehensive suite here so we'll test this in our internal repo