### PR TITLE
retry robustness

### DIFF
--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -113,11 +113,8 @@ class ClientTransport(Transport, Generic[HandshakeType]):
                 if last_error:
                     raise RiverException(
                         ERROR_HANDSHAKE,
-                        (
-                            f"No retry budget for {client_id} after "
-                            f"last failure: {str(last_error)}"
-                        ),
-                    )
+                        f"No retry budget for {client_id}"
+                    ) from last_error
                 else:
                     raise RiverException(
                         ERROR_HANDSHAKE, f"No retry budget for {client_id}"

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -151,13 +151,19 @@ class ClientTransport(Transport, Generic[HandshakeType]):
                 last_error = e
                 backoff_time = rate_limit.get_backoff_ms(client_id)
                 logger.exception(
-                    f"Error connecting: {str(e)}, retrying with {backoff_time}ms backoff"
+                    (
+                        f"Error connecting: {str(e)}, "
+                        f"retrying with {backoff_time}ms backoff"
+                    )
                 )
                 await asyncio.sleep(backoff_time / 1000)
 
         raise RiverException(
             ERROR_HANDSHAKE,
-            f"Failed to create ws after retrying max number of times: {str(last_error)}",
+            (
+                f"Failed to create ws after retrying {max_retry} number of times: "
+                f"{str(last_error)}"
+            ),
         )
 
     async def _create_new_session(

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -110,9 +110,18 @@ class ClientTransport(Transport, Generic[HandshakeType]):
                 logger.info(f"Retrying build handshake number {i} times")
             if not rate_limit.has_budget(client_id):
                 logger.debug("No retry budget for %s.", client_id)
-                raise RiverException(
-                    ERROR_HANDSHAKE, f"No retry budget for {client_id}"
-                )
+                if last_error:
+                    raise RiverException(
+                        ERROR_HANDSHAKE,
+                        (
+                            f"No retry budget for {client_id} after "
+                            f"last failure: {str(last_error)}"
+                        ),
+                    )
+                else:
+                    raise RiverException(
+                        ERROR_HANDSHAKE, f"No retry budget for {client_id}"
+                    )
 
             rate_limit.consume_budget(client_id)
 

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -104,7 +104,7 @@ class ClientTransport(Transport, Generic[HandshakeType]):
         client_id = self._client_id
         logger.info("Attempting to establish new ws connection")
 
-        last_error = None
+        last_error: Optional[Exception] = None
         for i in range(max_retry):
             if i > 0:
                 logger.info(f"Retrying build handshake number {i} times")


### PR DESCRIPTION
Why + What changed
===

- add details about what failed where possible instead of just overriding the error with "Failed to create ws after retrying max number of times"
- construct `handshake_metadata` earlier so if the await fails it is before ws is established

the plan is to also stop proc level retries within ai-infra on handshake errors because otherwise we get an explosion of connection attempts:
- single failure (either due to pid2 crashing or other reasons)
- causes retry at the proc level
- each proc level failure will retry the underlying transport connection 5 times

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
