### PR TITLE
Combine uri and metadata factory

### DIFF
--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -1,9 +1,13 @@
 import logging
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
-from typing import Any, Generic, Optional, TypeVar, Union
+from typing import Any, Generic, Optional, Union
 
 from replit_river.client_transport import ClientTransport
-from replit_river.transport_options import TransportOptions
+from replit_river.transport_options import (
+    HandshakeMetadataType,
+    TransportOptions,
+    UriAndMetadata,
+)
 
 from .rpc import (
     ErrorType,
@@ -15,26 +19,23 @@ from .rpc import (
 logger = logging.getLogger(__name__)
 
 
-HandshakeType = TypeVar("HandshakeType")
-
-
-class Client(Generic[HandshakeType]):
+class Client(Generic[HandshakeMetadataType]):
     def __init__(
         self,
-        websocket_uri_factory: Callable[[], Awaitable[str]],
+        uri_and_metadata_factory: Callable[
+            [], Awaitable[UriAndMetadata[HandshakeMetadataType]]
+        ],
         client_id: str,
         server_id: str,
         transport_options: TransportOptions,
-        handshake_metadata_factory: Callable[[], Awaitable[HandshakeType]],
     ) -> None:
         self._client_id = client_id
         self._server_id = server_id
-        self._transport = ClientTransport[HandshakeType](
-            websocket_uri_factory=websocket_uri_factory,
+        self._transport = ClientTransport[HandshakeMetadataType](
+            uri_and_metadata_factory=uri_and_metadata_factory,
             client_id=client_id,
             server_id=server_id,
             transport_options=transport_options,
-            handshake_metadata_factory=handshake_metadata_factory,
         )
 
     async def close(self) -> None:

--- a/replit_river/rpc.py
+++ b/replit_river/rpc.py
@@ -30,7 +30,10 @@ from replit_river.error_schema import (
     stringify_exception,
 )
 from replit_river.task_manager import BackgroundTaskManager
-from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE
+from replit_river.transport_options import (
+    MAX_MESSAGE_BUFFER_SIZE,
+    HandshakeMetadataType,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,15 +65,12 @@ class ExpectedSessionState(BaseModel):
     nextSentSeq: Optional[int] = None
 
 
-HandshakeType = TypeVar("HandshakeType")
-
-
-class ControlMessageHandshakeRequest(BaseModel, Generic[HandshakeType]):
+class ControlMessageHandshakeRequest(BaseModel, Generic[HandshakeMetadataType]):
     type: Literal["HANDSHAKE_REQ"] = "HANDSHAKE_REQ"
     protocolVersion: str
     sessionId: str
     expectedSessionState: ExpectedSessionState
-    metadata: Optional[HandshakeType] = None
+    metadata: Optional[HandshakeMetadataType] = None
 
 
 class HandShakeStatus(BaseModel):

--- a/replit_river/transport_options.py
+++ b/replit_river/transport_options.py
@@ -1,4 +1,5 @@
 import os
+from typing import Generic, TypedDict, TypeVar
 
 from pydantic import BaseModel
 
@@ -50,3 +51,11 @@ class TransportOptions(BaseModel):
             heartbeat_ms=heartbeat_ms,
             heartbeats_until_dead=heartbeats_to_dead,
         )
+
+
+HandshakeMetadataType = TypeVar("HandshakeMetadataType")
+
+
+class UriAndMetadata(TypedDict, Generic[HandshakeMetadataType]):
+    uri: str
+    metadata: HandshakeMetadataType

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from websockets.server import serve
 
 from replit_river.client import Client
+from replit_river.client_transport import UriAndMetadata
 from replit_river.error_schema import RiverError
 from replit_river.rpc import (
     GrpcContext,
@@ -138,20 +139,19 @@ async def client(
     no_logging_error: NoErrors,
 ) -> AsyncGenerator[Client, None]:
 
-    async def websocket_uri_factory() -> str:
-        return "ws://localhost:8765"
-
-    async def handshake_metadata_factory() -> None:
-        return None
+    async def websocket_uri_factory() -> UriAndMetadata[None]:
+        return {
+            "uri": "ws://localhost:8765",
+            "metadata": None,
+        }
 
     try:
         async with serve(server.serve, "localhost", 8765):
-            client: Client[Literal[None]] = Client(
-                websocket_uri_factory,
+            client: Client[Literal[None]] = Client[None](
+                uri_and_metadata_factory=websocket_uri_factory,
                 client_id="test_client",
                 server_id="test_server",
                 transport_options=transport_options,
-                handshake_metadata_factory=handshake_metadata_factory,
             )
             try:
                 yield client


### PR DESCRIPTION
Why
===

It's unnecessary to have two functions. With the way our metadata and websocket uri are setup, it's just added complexity

What changed
============

- Make `handshake_metadata_factory` and `websocket_uri_factory` a single `uri_and_metadata_factory` that grabs both. 
- Returns a new TypeDict `UriAndMetadata`
- Rename `HandshakeType` to `HandshakeMetadataType`
- `HandshakeMetadataType` `TypeVar` is reused (not sure if i'm doing some python no-no here). Also moved it to the options module to avoid circular imports

