### PR TITLE
Remove prefix bytes shenanigans

### DIFF
--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -250,7 +250,6 @@ class ClientTransport(Transport, Generic[HandshakeMetadataType]):
                     payload=handshake_request.model_dump(),
                 ),
                 ws=websocket,
-                prefix_bytes=self._transport_options.get_prefix_bytes(),
                 websocket_closed_callback=websocket_closed_callback,
             )
             return handshake_request

--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -317,7 +317,6 @@ class Session(object):
                 await self._send_transport_message(
                     msg,
                     websocket,
-                    prefix_bytes=self._transport_options.get_prefix_bytes(),
                 )
             except WebsocketClosedException:
                 logger.info(
@@ -332,11 +331,10 @@ class Session(object):
         self,
         msg: TransportMessage,
         websocket: websockets.WebSocketCommonProtocol,
-        prefix_bytes: bytes = b"",
     ) -> None:
         try:
             await send_transport_message(
-                msg, websocket, self._begin_close_session_countdown, prefix_bytes
+                msg, websocket, self._begin_close_session_countdown
             )
         except WebsocketClosedException as e:
             raise e
@@ -401,7 +399,6 @@ class Session(object):
                 await self._send_transport_message(
                     msg,
                     self._ws_wrapper.ws,
-                    prefix_bytes=self._transport_options.get_prefix_bytes(),
                 )
         except WebsocketClosedException as e:
             logger.debug(

--- a/replit_river/transport_options.py
+++ b/replit_river/transport_options.py
@@ -3,8 +3,6 @@ from typing import Generic, TypedDict, TypeVar
 
 from pydantic import BaseModel
 
-CROSIS_PREFIX_BYTES = b"\x00\x00"
-PID2_PREFIX_BYTES = b"\xff\xff"
 MAX_MESSAGE_BUFFER_SIZE = 1024
 
 
@@ -25,14 +23,10 @@ class TransportOptions(BaseModel):
     heartbeat_ms: float = 2_500
     # TODO: This should have a better name like max_failed_heartbeats
     heartbeats_until_dead: int = 4
-    use_prefix_bytes: bool = False
     close_session_check_interval_ms: float = 100
     connection_retry_options: ConnectionRetryOptions = ConnectionRetryOptions()
     buffer_size: int = 1_000
     transparent_reconnect: bool = True
-
-    def get_prefix_bytes(self) -> bytes:
-        return PID2_PREFIX_BYTES if self.use_prefix_bytes else b""
 
     def websocket_disconnect_grace_ms(self) -> float:
         return self.heartbeat_ms * self.heartbeats_until_dead


### PR DESCRIPTION
Why
===

There was a world where we muxed crosis/pid1 and river/pid2 over one websocket, so we had some prefix bytes. We killed that months ago. Just cleaning up.

What changed
============

:yeet:

Test plan
=========

river rivers