### PR TITLE
Add datadog tracing

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -67,6 +67,17 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "bytecode"
+version = "0.15.1"
+description = "Python module to generate and modify bytecode"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "bytecode-0.15.1-py3-none-any.whl", hash = "sha256:0a1dc340cac823cff605609b8b214f7f9bf80418c6b9e0fc8c6db1793c27137d"},
+    {file = "bytecode-0.15.1.tar.gz", hash = "sha256:7263239a8d3f70fc7c303862b20cd2c6788052e37ce0a26e67309d280e985984"},
+]
+
+[[package]]
 name = "chardet"
 version = "5.2.0"
 description = "Universal encoding detector for Python 3"
@@ -187,6 +198,108 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "ddtrace"
+version = "2.13.0"
+description = "Datadog APM client library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ddtrace-2.13.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:cc8b4957b1e2beb0527865392a3edcdefbb759fbecb791c711d2be45144ac984"},
+    {file = "ddtrace-2.13.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:c7adcf3e36b113bd9309d1132cd4d219e350365925b115eb6d7e4f71b402f58d"},
+    {file = "ddtrace-2.13.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f9564f4799d7b1abfa98317e041e7e7d97490f01e0cac74b32836739276417"},
+    {file = "ddtrace-2.13.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:827d3c7266826acee0d2a45e624f6cca527b91fd570b6dc729414754d932f533"},
+    {file = "ddtrace-2.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc99859b8abca416645871d012a5a0f250aba853caecb12d04e828d54de9b322"},
+    {file = "ddtrace-2.13.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:68c624bdf0a7694270791fad30ecd2cbabef2c917634a10de2ae40f92bc1026f"},
+    {file = "ddtrace-2.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a3252e70d4a1e5fe4f91fbc02a01cf53f6459e28955769a28f9b642e56c3a149"},
+    {file = "ddtrace-2.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0de86840376cb45c2a3d488945040cd1f615c725263c08dc9dc458cfcd9c6b7e"},
+    {file = "ddtrace-2.13.0-cp310-cp310-win32.whl", hash = "sha256:c568932d8958cb44b3a9a9f21d68ecb4dff5479718af25434245f35c141a4939"},
+    {file = "ddtrace-2.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:b2060b41ea60bd0248bc9db6343edb3d3277a47be73696038ef37d657e46e7a7"},
+    {file = "ddtrace-2.13.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:42c931e489d12e2c0a6d5cb4f582aad8c74ddb4ccb465c7cb1b0dacfb2b733f0"},
+    {file = "ddtrace-2.13.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:a7291d2840f2f35fd705e6d273bb05f55dfd07140bdb8539b1b4f2e6be388605"},
+    {file = "ddtrace-2.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d15bc0119fe626a38453ece0f7d77d4f3481ddff7ac72a166450694638533645"},
+    {file = "ddtrace-2.13.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ec93f049d7c3cd393d239fbc58f3d878de429a10a50d195dd486d4b5e1d70ade"},
+    {file = "ddtrace-2.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eee1a3d448d01fa4df9505eac3cb30b595cfad84884d22df0e3d3ceba53d9f6"},
+    {file = "ddtrace-2.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae3b521391f7d3370a2d19fe811d2baa8f5bdb181dffe8bde2d5852c12b61077"},
+    {file = "ddtrace-2.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d97fdb1a04266b64814f01ab6839ffc5bca14daa717b185cce344df4b549b411"},
+    {file = "ddtrace-2.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3121bac3b913553473d042109c175111e1afc0c8280ea88661591cf896d5055c"},
+    {file = "ddtrace-2.13.0-cp311-cp311-win32.whl", hash = "sha256:bb31153224b2f1240d88783a03caafd476a1e1b2da2c4e6a1eaaf718a9aa7a22"},
+    {file = "ddtrace-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:9aafa3f578301965b7642f5734563e813922482eeb37fa3a56c4e496379d7fe3"},
+    {file = "ddtrace-2.13.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:b89d46cf2df5981b165c8aacc5df5236c189011de8424836539d65501f743b33"},
+    {file = "ddtrace-2.13.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:a85280b947ecd13371e68cf790359c7842d53050b2ad25a1360102b1caf3481a"},
+    {file = "ddtrace-2.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f6bc77d02ba67f50bc52d1ed041dd7f9e3d9e0ada80f18b85e79f26515c1104"},
+    {file = "ddtrace-2.13.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5c681b39527d8cc1e59e699f60f0401f067efc146f325816d59ac344b71ae733"},
+    {file = "ddtrace-2.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d120906ce5cde152a82a5fdf02ee6be1e9a955719221e95477dbcd86c3f38783"},
+    {file = "ddtrace-2.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ff69b557b2a5b0293a63613feb2a21015e240da17a97a5f8f0ce5c0f53108bfa"},
+    {file = "ddtrace-2.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c12ba9f0c7c02f035e8d167867863e5b0475eada5d4a774aa8f58cdadae90d63"},
+    {file = "ddtrace-2.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:79a4d8dc730b2d2e16f0cbabc19a2826642bf2e3f6a051ba20b84538060cc2c7"},
+    {file = "ddtrace-2.13.0-cp312-cp312-win32.whl", hash = "sha256:ce79a48deca6b1414dfaf8a368337258285625baebed58562e98a0648c400b00"},
+    {file = "ddtrace-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:3c678c572de3c39ccf32a4df2fc35e20fe355ee5967fe13037e44258234f27d4"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-macosx_12_0_x86_64.whl", hash = "sha256:374626db3cd96080235794cfc8e2678382671d364e09b6d38859c2f7f69f8704"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd7128ee7e8fb70231879ccb1f2f87b79fabfef15c6f5d10a3fb70e58450e535"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:505fea65d34dbd03c8a71652045df7faf3f8a2948a08b9fe3888742bd9d15233"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74270c26142516e81a5c9d537e4dfc1719c237c0ceeca2389768e4f18133b17e"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5b68f0b7d7183f461f90f80f197b3b7c40d9da90c3214a9aeb69ba26aeef3c85"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e6b5a462cff369bf3047efe8f2bd7134ba71a66266064853014dd1e9b534e536"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:1ec24c98aba3251a3a9e8de2eb33e614681343ef3932b6c6cf731b56fd47e18b"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-win32.whl", hash = "sha256:feba681d0f6ca39aa16b35d755924a1cf762c32b84bdae19e8266d2e2e45b547"},
+    {file = "ddtrace-2.13.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c2f008c625712f6cfe621bcbb2da82ca0c126299b3bb8dd08debe7be4ec2776d"},
+    {file = "ddtrace-2.13.0-cp38-cp38-macosx_12_0_universal2.whl", hash = "sha256:215d8fcc9d8449b2c9f0aca178a0022f7083bbda27d07cb91a1081a735fe6516"},
+    {file = "ddtrace-2.13.0-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:48e3b76d8c2b804430bd222308e22cc05f9a67266ddd0707cf342d0151414b71"},
+    {file = "ddtrace-2.13.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29b2e28368bdf4da8945ba78241a8293ba4fa8a246f04869061290b4297831e6"},
+    {file = "ddtrace-2.13.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:90503ea1fe9de78008bc0ca25851334e9aa9bc5b3cbc62a47e1e5b090201a002"},
+    {file = "ddtrace-2.13.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ccf51c3a31283fe74f2ad06b96beccf69754499cbbb00e4055ac43b98fbe7392"},
+    {file = "ddtrace-2.13.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:35c7230604b0cecf4390255fc3f1736624f725a2158983fc8680901369b997bb"},
+    {file = "ddtrace-2.13.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:47b2fc7cc4b4d44da97bfe1de78c03b1d306ce8609ae5efcd1004460cf0ad43e"},
+    {file = "ddtrace-2.13.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:369f6d701e37d52edcaef3a36312ee1d3277513fdc9816a8c0b66caa74b12e25"},
+    {file = "ddtrace-2.13.0-cp38-cp38-win32.whl", hash = "sha256:7449d83c76b832728a5516b4e44077aab88cda5df8e1d899eb98e63e0f7559f8"},
+    {file = "ddtrace-2.13.0-cp38-cp38-win_amd64.whl", hash = "sha256:eceafb5900913e2d69f40624faccd2d6a398fdd5ce1f22ff3527e991e19de9a0"},
+    {file = "ddtrace-2.13.0-cp39-cp39-macosx_12_0_universal2.whl", hash = "sha256:974631565f374bd1a4f6865c0c41ba5d638a39db59553c51702c868df58af31c"},
+    {file = "ddtrace-2.13.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:9622e83681688b342a6ca6952daac4b4990cd6e3d041a3a178c6eba0de54e564"},
+    {file = "ddtrace-2.13.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:829d588b19d6d838c8396e518d45aa1733a0419c077e1fee08b55638754e995c"},
+    {file = "ddtrace-2.13.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d62a1592f7a145bf332562826a6699cb574aedbd2f9dbdcb53ead65adcf3a5e"},
+    {file = "ddtrace-2.13.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6d88c12339e2834ea2a9c09e8d15b69766fa4bd39f944b2b0cdbc72edcf860e"},
+    {file = "ddtrace-2.13.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bf34ba2889758cbc4b44940c615fcdd1d2857272b47e6b679d3587c661651431"},
+    {file = "ddtrace-2.13.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:084eb3f8031ea2cbf7d3d9b3e622dcc1fa75bf821fcdff2084d15635d51a28b2"},
+    {file = "ddtrace-2.13.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a8771b9384b2af5a5e761e9b78142e4e4433c1a917a5ff8d5308acce51766dc9"},
+    {file = "ddtrace-2.13.0-cp39-cp39-win32.whl", hash = "sha256:4c87f1ce25b325427030b1d2dc7433f4a48b8d6495b4a1fd5bff0e8e2b2882dc"},
+    {file = "ddtrace-2.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:a9b12e45b377d93a4e2cc493b8303495624299981954cb401f4551768a81854d"},
+    {file = "ddtrace-2.13.0.tar.gz", hash = "sha256:9ddb25786fbb151660d36614f5596de9ab90c4083e8b980c4e06a4d7b54dfbcd"},
+]
+
+[package.dependencies]
+bytecode = [
+    {version = ">=0.15.0", markers = "python_version >= \"3.12.0\""},
+    {version = ">=0.14.0", markers = "python_version ~= \"3.11.0\""},
+]
+envier = ">=0.5,<1.0"
+opentelemetry-api = ">=1"
+protobuf = ">=3"
+typing-extensions = "*"
+wrapt = ">=1"
+xmltodict = ">=0.12"
+
+[package.extras]
+openai = ["tiktoken"]
+opentracing = ["opentracing (>=2.0.0)"]
+
+[[package]]
+name = "deprecated"
+version = "1.2.14"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "Deprecated-1.2.14-py2.py3-none-any.whl", hash = "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c"},
+    {file = "Deprecated-1.2.14.tar.gz", hash = "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"},
+]
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
+
+[[package]]
 name = "deptry"
 version = "0.14.2"
 description = "A command line utility to check for unused, missing and transitive dependencies in a Python project."
@@ -210,6 +323,20 @@ chardet = ">=4.0.0"
 click = ">=8.0.0,<9"
 colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
 pathspec = ">=0.9.0"
+
+[[package]]
+name = "envier"
+version = "0.5.2"
+description = "Python application configuration via the environment"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "envier-0.5.2-py3-none-any.whl", hash = "sha256:65099cf3aa9b3b3b4b92db2f7d29e2910672e085b76f7e587d2167561a834add"},
+    {file = "envier-0.5.2.tar.gz", hash = "sha256:4e7e398cb09a8dd360508ef7e12511a152355426d2544b8487a34dad27cc20ad"},
+]
+
+[package.extras]
+mypy = ["mypy"]
 
 [[package]]
 name = "grpcio"
@@ -330,6 +457,25 @@ files = [
 grpcio = ">=1.62.3"
 protobuf = ">=4.21.6,<5.0dev"
 setuptools = "*"
+
+[[package]]
+name = "importlib-metadata"
+version = "8.4.0"
+description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "importlib_metadata-8.4.0-py3-none-any.whl", hash = "sha256:66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1"},
+    {file = "importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5"},
+]
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+perf = ["ipython"]
+test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -500,6 +646,21 @@ files = [
     {file = "nanoid-2.0.0-py3-none-any.whl", hash = "sha256:90aefa650e328cffb0893bbd4c236cfd44c48bc1f2d0b525ecc53c3187b653bb"},
     {file = "nanoid-2.0.0.tar.gz", hash = "sha256:5a80cad5e9c6e9ae3a41fa2fb34ae189f7cb420b2a5d8f82bd9d23466e4efa68"},
 ]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.27.0"
+description = "OpenTelemetry Python API"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "opentelemetry_api-1.27.0-py3-none-any.whl", hash = "sha256:953d5871815e7c30c81b56d910c707588000fff7a3ca1c73e6531911d53065e7"},
+    {file = "opentelemetry_api-1.27.0.tar.gz", hash = "sha256:ed673583eaa5f81b5ce5e86ef7cdaf622f88ef65f0b9aab40b843dcae5bef342"},
+]
+
+[package.dependencies]
+deprecated = ">=1.2.6"
+importlib-metadata = ">=6.0,<=8.4.0"
 
 [[package]]
 name = "packaging"
@@ -927,7 +1088,116 @@ files = [
     {file = "websockets-12.0.tar.gz", hash = "sha256:81df9cbcbb6c260de1e007e58c011bfebe2dafc8435107b0537f393dd38c8b1b"},
 ]
 
+[[package]]
+name = "wrapt"
+version = "1.16.0"
+description = "Module for decorators, wrappers and monkey patching."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"},
+    {file = "wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136"},
+    {file = "wrapt-1.16.0-cp310-cp310-win32.whl", hash = "sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d"},
+    {file = "wrapt-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2"},
+    {file = "wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09"},
+    {file = "wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d"},
+    {file = "wrapt-1.16.0-cp311-cp311-win32.whl", hash = "sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362"},
+    {file = "wrapt-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89"},
+    {file = "wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b"},
+    {file = "wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c"},
+    {file = "wrapt-1.16.0-cp312-cp312-win32.whl", hash = "sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc"},
+    {file = "wrapt-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8"},
+    {file = "wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465"},
+    {file = "wrapt-1.16.0-cp36-cp36m-win32.whl", hash = "sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e"},
+    {file = "wrapt-1.16.0-cp36-cp36m-win_amd64.whl", hash = "sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966"},
+    {file = "wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c"},
+    {file = "wrapt-1.16.0-cp37-cp37m-win32.whl", hash = "sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c"},
+    {file = "wrapt-1.16.0-cp37-cp37m-win_amd64.whl", hash = "sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00"},
+    {file = "wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0"},
+    {file = "wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6"},
+    {file = "wrapt-1.16.0-cp38-cp38-win32.whl", hash = "sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b"},
+    {file = "wrapt-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41"},
+    {file = "wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2"},
+    {file = "wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537"},
+    {file = "wrapt-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3"},
+    {file = "wrapt-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35"},
+    {file = "wrapt-1.16.0-py3-none-any.whl", hash = "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"},
+    {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
+]
+
+[[package]]
+name = "xmltodict"
+version = "0.13.0"
+description = "Makes working with XML feel like you are working with JSON"
+optional = false
+python-versions = ">=3.4"
+files = [
+    {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
+    {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
+]
+
+[[package]]
+name = "zipp"
+version = "3.20.2"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
+    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+type = ["pytest-mypy"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b96e32fb2baa6d31d862af081a0243584a8da6355d6f54897820ceb18d247f98"
+content-hash = "87a6ac638fe2e8edee1d0b8ef6122648565db41954cbb9d49c0eb74ecfa8ae84"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ websockets = "^12.0"
 pydantic-core = "^2.20.1"
 msgpack-types = "^0.3.0"
 pydantic = "=2.9.0b1"
+ddtrace = "^2.13.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -2,6 +2,8 @@ import logging
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from typing import Any, Generic, Optional, TypeVar, Union
 
+from ddtrace import tracer
+
 from replit_river.client_transport import ClientTransport
 from replit_river.transport_options import TransportOptions
 
@@ -54,15 +56,16 @@ class Client(Generic[HandshakeType]):
         response_deserializer: Callable[[Any], ResponseType],
         error_deserializer: Callable[[Any], ErrorType],
     ) -> ResponseType:
-        session = await self._transport.get_or_create_session()
-        return await session.send_rpc(
-            service_name,
-            procedure_name,
-            request,
-            request_serializer,
-            response_deserializer,
-            error_deserializer,
-        )
+        with tracer.trace("pid2.client", resource=f"{service_name}.{procedure_name}"):
+            session = await self._transport.get_or_create_session()
+            return await session.send_rpc(
+                service_name,
+                procedure_name,
+                request,
+                request_serializer,
+                response_deserializer,
+                error_deserializer,
+            )
 
     async def send_upload(
         self,
@@ -75,17 +78,18 @@ class Client(Generic[HandshakeType]):
         response_deserializer: Callable[[Any], ResponseType],
         error_deserializer: Callable[[Any], ErrorType],
     ) -> ResponseType:
-        session = await self._transport.get_or_create_session()
-        return await session.send_upload(
-            service_name,
-            procedure_name,
-            init,
-            request,
-            init_serializer,
-            request_serializer,
-            response_deserializer,
-            error_deserializer,
-        )
+        with tracer.trace("pid2.client", resource=f"{service_name}.{procedure_name}"):
+            session = await self._transport.get_or_create_session()
+            return await session.send_upload(
+                service_name,
+                procedure_name,
+                init,
+                request,
+                init_serializer,
+                request_serializer,
+                response_deserializer,
+                error_deserializer,
+            )
 
     async def send_subscription(
         self,
@@ -96,15 +100,16 @@ class Client(Generic[HandshakeType]):
         response_deserializer: Callable[[Any], ResponseType],
         error_deserializer: Callable[[Any], ErrorType],
     ) -> AsyncIterator[Union[ResponseType, ErrorType]]:
-        session = await self._transport.get_or_create_session()
-        return session.send_subscription(
-            service_name,
-            procedure_name,
-            request,
-            request_serializer,
-            response_deserializer,
-            error_deserializer,
-        )
+        with tracer.trace("pid2.client", resource=f"{service_name}.{procedure_name}"):
+            session = await self._transport.get_or_create_session()
+            return session.send_subscription(
+                service_name,
+                procedure_name,
+                request,
+                request_serializer,
+                response_deserializer,
+                error_deserializer,
+            )
 
     async def send_stream(
         self,
@@ -117,14 +122,15 @@ class Client(Generic[HandshakeType]):
         response_deserializer: Callable[[Any], ResponseType],
         error_deserializer: Callable[[Any], ErrorType],
     ) -> AsyncIterator[Union[ResponseType, ErrorType]]:
-        session = await self._transport.get_or_create_session()
-        return session.send_stream(
-            service_name,
-            procedure_name,
-            init,
-            request,
-            init_serializer,
-            request_serializer,
-            response_deserializer,
-            error_deserializer,
-        )
+        with tracer.trace("pid2.client", resource=f"{service_name}.{procedure_name}"):
+            session = await self._transport.get_or_create_session()
+            return session.send_stream(
+                service_name,
+                procedure_name,
+                init,
+                request,
+                init_serializer,
+                request_serializer,
+                response_deserializer,
+                error_deserializer,
+            )


### PR DESCRIPTION
Why
===

It would be nice to have spans for all the pid2 requests

What changed
============

- Add datadog spans for all rpcs types

Test plan
=========

- Update agent to use new version of the package
- Run some agent runs
- See pid2 spans!

