### PR TITLE
[codegen] Don't provide two defaults

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -380,11 +380,7 @@ def encode_type(
                     if name not in type.required:
                         value = ""
                         if base_model != "TypedDict":
-                            args = f"alias='{name}', default=None"
-                            if field_value != "...":
-                                value = f" = Field({field_value}, {args})"
-                            else:
-                                value = f" = Field({args})"
+                            value = f"Field(default=None, alias='{name}')"
                         current_chunks.append(f"  kind: Optional[{type_name}]{value}")
                     else:
                         value = ""


### PR DESCRIPTION
Why
===

Turns out that if we have an optional literal field, we were trying to provide a default for the literal and also for the optional. mypy was not having it.

What changed
============

This change chooses just one: the optional.

Test plan
=========

https://replit.semaphoreci.com/jobs/8dac3b8a-1803-4903-8acd-515e278789f2/summary does not happen anymore.