### PR TITLE
[p_unification] I, for one, welcome our new nix overlords

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+use flake
+dotenv_if_exists
+source_env_if_exists .local.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ cython_debug/
 
 # Vscode
 .vscode/
+
+# nix
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727451550,
+        "narHash": "sha256-8FMA1aARgAbtVfDX1zTi25JoIjm6O7jqmqNhH/bKAMY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ed96506b5dcbb8d34ffe8ae0499d194ccfe9c71d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "A flake that provides tools needed to hack on river-python";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+  outputs = { self, nixpkgs }: let
+    mkPkgs = system: import nixpkgs {
+      inherit system;
+    };
+    mkDevShell = system:
+    let
+      pkgs = mkPkgs system;
+      replitNixDeps = (import ./replit.nix { pkgs = pkgs; }).deps;
+    in
+    pkgs.mkShell {
+      env = {
+        # Needed for Python/gRPC to be able to interact with libstdc++.
+        LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+      };
+      packages = replitNixDeps;
+    };
+  in
+  {
+    devShells.aarch64-darwin.default = mkDevShell "aarch64-darwin";
+    devShells.x86_64-linux.default = mkDevShell "x86_64-linux";
+  };
+}


### PR DESCRIPTION
Why
===

This repository hadn't been fully nixified.

What changed
============

This repository is now fully nixified.

Test plan
=========

```
direnv allow && poetry shell

python -m replit_river.codegen
```

no longer crashes due to a lack of stlibc++.so.