### PR TITLE
[codegen] Fix a typo

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -380,7 +380,7 @@ def encode_type(
                     if name not in type.required:
                         value = ""
                         if base_model != "TypedDict":
-                            value = f"Field(default=None, alias='{name}')"
+                            value = f" = Field(default=None, alias='{name}')"
                         current_chunks.append(f"  kind: Optional[{type_name}]{value}")
                     else:
                         value = ""


### PR DESCRIPTION
Why
===

Oops, my lack of nix prevented me from actually running the code.

What changed
============

This time the code has been run.

Test plan
=========

```shell
python -m replit_river.codegen client --output /app/ai-infra/pkgs/pid2_client/src/pid2_client/pid2_client.py --client-name Pid2 /app/ai-infra/pkgs/pid2_client/src/schema/schema.json
```

```diff
diff --git a/pkgs/pid2_client/src/pid2_client/pid2_client.py b/pkgs/pid2_client/src/pid2_client/pid2_client.py
index aafa12bb..53c76f19 100644
--- a/pkgs/pid2_client/src/pid2_client/pid2_client.py
+++ b/pkgs/pid2_client/src/pid2_client/pid2_client.py
@@ -1,4 +1,3 @@
-# ruff: noqa
 # Code generated by river.codegen. DO NOT EDIT.
 from collections.abc import AsyncIterable, AsyncIterator
 import datetime
@@ -11512,7 +11511,7 @@ class ExcalidrawUpdateInputPointer(BaseModel):
 class ExcalidrawUpdateInput(BaseModel):
     paneId: Optional[str] = None
     path: Optional[str] = None
-    kind: Optional[Literal["leave"]] = Field("leave", alias="$kind", default=None)
+    kind: Optional[Literal["leave"]] = Field(default=None, alias="$kind")
     elements: Optional[str] = None
     pointer: Optional[ExcalidrawUpdateInputPointer] = None
     selectedElementIds: Optional[Dict[str, bool]] = None
@@ -11561,7 +11560,7 @@ class ExcalidrawListenOutputPointer(BaseModel):


 class ExcalidrawListenOutput(BaseModel):
-    kind: Optional[Literal["leave"]] = Field("leave", alias="$kind", default=None)
+    kind: Optional[Literal["leave"]] = Field(default=None, alias="$kind")
     elements: Optional[str] = None
     pointer: Optional[ExcalidrawListenOutputPointer] = None
     selectedElementIds: Optional[Dict[str, bool]] = None
```