### PR TITLE
feat/finishing typeddict inputs

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,3 +5,12 @@ warn_return_any = True
 
 [mypy-grpc.*]
 ignore_missing_imports = True
+
+[mypy-parity.gen.*]
+ignore_missing_imports = True
+
+[mypy-pyd.*]
+ignore_missing_imports = True
+
+[mypy-tyd.*]
+ignore_missing_imports = True

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -273,44 +273,44 @@ def encode_type(
             # Handle the case where type is not specified
             typeddict_encoder.append("x")
             return ("Any", ())
-        if type.type == "string":
+        elif type.type == "string":
             if type.const:
                 typeddict_encoder.append(f"'{type.const}'")
                 return (f"Literal['{type.const}']", ())
             else:
                 typeddict_encoder.append("x")
                 return ("str", ())
-        if type.type == "Uint8Array":
+        elif type.type == "Uint8Array":
             typeddict_encoder.append("x.decode()")
             return ("bytes", ())
-        if type.type == "number":
+        elif type.type == "number":
             if type.const is not None:
                 # enums are represented as const number in the schema
                 typeddict_encoder.append(f"{type.const}")
                 return (f"Literal[{type.const}]", ())
             typeddict_encoder.append("x")
             return ("float", ())
-        if type.type == "integer":
+        elif type.type == "integer":
             if type.const is not None:
                 # enums are represented as const number in the schema
                 typeddict_encoder.append(f"{type.const}")
                 return (f"Literal[{type.const}]", ())
             typeddict_encoder.append("x")
             return ("int", ())
-        if type.type == "boolean":
+        elif type.type == "boolean":
             typeddict_encoder.append("x")
             return ("bool", ())
-        if type.type == "null":
+        elif type.type == "null":
             typeddict_encoder.append("None")
             return ("None", ())
-        if type.type == "Date":
+        elif type.type == "Date":
             typeddict_encoder.append("TODO: dstewart")
             return ("datetime.datetime", ())
-        if type.type == "array" and type.items:
+        elif type.type == "array" and type.items:
             type_name, type_chunks = encode_type(type.items, prefix, base_model)
             typeddict_encoder.append("TODO: dstewart")
             return (f"List[{type_name}]", type_chunks)
-        if (
+        elif (
             type.type == "object"
             and type.patternProperties
             and "^(.*)$" in type.patternProperties

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -81,7 +81,7 @@ def reindent(prefix: str, code: str) -> str:
 
 
 def encode_type(
-    type: RiverType, prefix: str, base_model: str = "BaseModel"
+    type: RiverType, prefix: str, base_model: str
 ) -> Tuple[str, Sequence[str]]:
     chunks: List[str] = []
     if isinstance(type, RiverNotType):
@@ -449,7 +449,7 @@ def generate_river_client_module(
 
     if schema_root.handshakeSchema is not None:
         (handshake_type, handshake_chunks) = encode_type(
-            schema_root.handshakeSchema, "HandshakeSchema"
+            schema_root.handshakeSchema, "HandshakeSchema", "BaseModel"
         )
         chunks.extend(handshake_chunks)
     else:
@@ -482,7 +482,9 @@ def generate_river_client_module(
             )
             chunks.extend(input_chunks)
             output_type, output_chunks = encode_type(
-                procedure.output, f"{schema_name.title()}{name.title()}Output"
+                procedure.output,
+                f"{schema_name.title()}{name.title()}Output",
+                "BaseModel",
             )
             chunks.extend(output_chunks)
             if procedure.errors:

--- a/scripts/parity.sh
+++ b/scripts/parity.sh
@@ -25,4 +25,6 @@ gen() {
 gen tyd.py Pid2TypedDict --typed-dict-inputs
 gen pyd.py Pid2Pydantic
 
-poetry run bash -c "PYTHONPATH='${root}/src:${scripts}' python -m parity.check_parity"
+PYTHONPATH="${root}/src:${scripts}"
+poetry run bash -c "MYPYPATH='$PYTHONPATH' mypy -m parity.check_parity"
+poetry run bash -c "PYTHONPATH='$PYTHONPATH' python -m parity.check_parity"

--- a/scripts/parity.sh
+++ b/scripts/parity.sh
@@ -3,6 +3,8 @@
 # parity.sh: Generate Pydantic and TypedDict models and check for deep equality.
 #            This script expects that ai-infra is cloned alongside river-python.
 
+set -e
+
 scripts="$(dirname "$0")"
 cd "${scripts}/.."
 
@@ -11,15 +13,23 @@ mkdir "$root/src"
 
 echo "Using $root" >&2
 
+function cleanup {
+  if [ -z "${DEBUG}" ]; then
+    echo "Cleaning up..." >&2
+    rm -rfv "${root}" >&2
+  fi
+}
+trap "cleanup" 0 2 3 15
+
 gen() {
-        fname="$1"; shift
-        name="$1"; shift
-        poetry run python -m replit_river.codegen \
-                client \
-                --output "${root}/src/${fname}" \
-                --client-name "${name}" \
-                ../ai-infra/pkgs/pid2_client/src/schema/schema.json \
-                "$@"
+  fname="$1"; shift
+  name="$1"; shift
+  poetry run python -m replit_river.codegen \
+    client \
+    --output "${root}/src/${fname}" \
+    --client-name "${name}" \
+    ../ai-infra/pkgs/pid2_client/src/schema/schema.json \
+    "$@"
 }
 
 gen tyd.py Pid2TypedDict --typed-dict-inputs

--- a/scripts/parity.sh
+++ b/scripts/parity.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# parity.sh: Generate Pydantic and TypedDict models and check for deep equality.
+#            This script expects that ai-infra is cloned alongside river-python.
+
+scripts="$(dirname "$0")"
+cd "${scripts}/.."
+
+root="$(mktemp -d --tmpdir 'river-codegen-parity.XXX')"
+mkdir "$root/src"
+
+echo "Using $root" >&2
+
+gen() {
+        fname="$1"; shift
+        name="$1"; shift
+        poetry run python -m replit_river.codegen \
+                client \
+                --output "${root}/src/${fname}" \
+                --client-name "${name}" \
+                ../ai-infra/pkgs/pid2_client/src/schema/schema.json \
+                "$@"
+}
+
+gen tyd.py Pid2TypedDict --typed-dict-inputs
+gen pyd.py Pid2Pydantic
+
+poetry run bash -c "PYTHONPATH='${root}/src:${scripts}' python -m parity.check_parity"

--- a/scripts/parity/check_parity.py
+++ b/scripts/parity/check_parity.py
@@ -1,0 +1,137 @@
+from typing import Any, Callable, TypeVar
+
+import pyd
+import tyd
+from parity.gen import (
+    gen_bool,
+    gen_choice,
+    gen_dict,
+    gen_float,
+    gen_int,
+    gen_list,
+    gen_opt,
+    gen_str,
+)
+from pydantic import TypeAdapter
+
+A = TypeVar("A")
+
+
+def baseTestPattern(
+    x: A, encode: Callable[[A], Any], adapter: TypeAdapter[Any]
+) -> None:
+    a = encode(x)
+    m = adapter.validate_python(a)
+    z = adapter.dump_python(m)
+
+    assert a == z
+
+
+def testAiexecExecInit() -> None:
+    x: tyd.AiexecExecInit = {
+        "args": gen_list(gen_str)(),
+        "env": gen_opt(gen_dict(gen_str))(),
+        "cwd": gen_opt(gen_str)(),
+        "omitStdout": gen_opt(gen_bool)(),
+        "omitStderr": gen_opt(gen_bool)(),
+        "useReplitRunEnv": gen_opt(gen_bool)(),
+    }
+
+    baseTestPattern(x, tyd.encode_AiexecExecInit, TypeAdapter(pyd.AiexecExecInit))
+
+
+def testAgenttoollanguageserverOpendocumentInput() -> None:
+    x: tyd.AgenttoollanguageserverOpendocumentInput = {
+        "uri": gen_str(),
+        "languageId": gen_str(),
+        "version": gen_float(),
+        "text": gen_str(),
+    }
+
+    baseTestPattern(
+        x,
+        tyd.encode_AgenttoollanguageserverOpendocumentInput,
+        TypeAdapter(pyd.AgenttoollanguageserverOpendocumentInput),
+    )
+
+
+def testAgenttoollanguageserverGetcodesymbolInput() -> None:
+    x: tyd.AgenttoollanguageserverGetcodesymbolInput = {
+        "uri": gen_str(),
+        "position": {
+            "line": gen_float(),
+            "character": gen_float(),
+        },
+        "kind": gen_opt(gen_choice(list(range(1, 27))))(),
+    }
+
+    baseTestPattern(
+        x,
+        tyd.encode_AgenttoollanguageserverGetcodesymbolInput,
+        TypeAdapter(pyd.AgenttoollanguageserverGetcodesymbolInput),
+    )
+
+
+def testShellexecSpawnInput() -> None:
+    x: tyd.ShellexecSpawnInput = {
+        "cmd": gen_str(),
+        "args": gen_opt(gen_list(gen_str))(),
+        "initialCmd": gen_opt(gen_str)(),
+        "env": gen_opt(gen_dict(gen_str))(),
+        "cwd": gen_opt(gen_str)(),
+        "size": gen_opt(
+            lambda: {
+                "rows": gen_int(),
+                "cols": gen_int(),
+            }
+        )(),
+        "useReplitRunEnv": gen_opt(gen_bool)(),
+        "useCgroupMagic": gen_opt(gen_bool)(),
+        "interactive": gen_opt(gen_bool)(),
+    }
+
+    baseTestPattern(
+        x,
+        tyd.encode_ShellexecSpawnInput,
+        TypeAdapter(pyd.ShellexecSpawnInput),
+    )
+
+
+def testConmanfilesystemPersistInput() -> None:
+    x: tyd.ConmanfilesystemPersistInput = {
+        "cmd": gen_str(),
+        "args": gen_opt(gen_list(gen_str))(),
+        "initialCmd": gen_opt(gen_str)(),
+        "env": gen_opt(gen_dict(gen_str))(),
+        "cwd": gen_opt(gen_str)(),
+        "size": gen_opt(
+            lambda: {
+                "rows": gen_int(),
+                "cols": gen_int(),
+            }
+        )(),
+        "useReplitRunEnv": gen_opt(gen_bool)(),
+        "useCgroupMagic": gen_opt(gen_bool)(),
+        "interactive": gen_opt(gen_bool)(),
+    }
+
+    baseTestPattern(
+        x,
+        tyd.encode_ConmanfilesystemPersistInput,
+        TypeAdapter(pyd.ConmanfilesystemPersistInput),
+    )
+
+
+def main() -> None:
+    testAiexecExecInit()
+    testAgenttoollanguageserverOpendocumentInput()
+    testAgenttoollanguageserverGetcodesymbolInput()
+    testShellexecSpawnInput()
+    testConmanfilesystemPersistInput()
+
+
+if __name__ == "__main__":
+    print("Starting...")
+    for _ in range(0, 100):
+        main()
+    print("Verified")

--- a/scripts/parity/check_parity.py
+++ b/scripts/parity/check_parity.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Literal, TypedDict, TypeVar, Union, cast
 
 import pyd
 import tyd
@@ -55,6 +55,37 @@ def testAgenttoollanguageserverOpendocumentInput() -> None:
     )
 
 
+kind_type = Union[
+    Literal[1],
+    Literal[2],
+    Literal[3],
+    Literal[4],
+    Literal[5],
+    Literal[6],
+    Literal[7],
+    Literal[8],
+    Literal[9],
+    Literal[10],
+    Literal[11],
+    Literal[12],
+    Literal[13],
+    Literal[14],
+    Literal[15],
+    Literal[16],
+    Literal[17],
+    Literal[18],
+    Literal[19],
+    Literal[20],
+    Literal[21],
+    Literal[22],
+    Literal[23],
+    Literal[24],
+    Literal[25],
+    Literal[26],
+    None,
+]
+
+
 def testAgenttoollanguageserverGetcodesymbolInput() -> None:
     x: tyd.AgenttoollanguageserverGetcodesymbolInput = {
         "uri": gen_str(),
@@ -62,7 +93,7 @@ def testAgenttoollanguageserverGetcodesymbolInput() -> None:
             "line": gen_float(),
             "character": gen_float(),
         },
-        "kind": gen_opt(gen_choice(list(range(1, 27))))(),
+        "kind": cast(kind_type, gen_opt(gen_choice(list(range(1, 27))))()),
     }
 
     baseTestPattern(
@@ -70,6 +101,11 @@ def testAgenttoollanguageserverGetcodesymbolInput() -> None:
         tyd.encode_AgenttoollanguageserverGetcodesymbolInput,
         TypeAdapter(pyd.AgenttoollanguageserverGetcodesymbolInput),
     )
+
+
+class size_type(TypedDict):
+    rows: int
+    cols: int
 
 
 def testShellexecSpawnInput() -> None:
@@ -80,10 +116,13 @@ def testShellexecSpawnInput() -> None:
         "env": gen_opt(gen_dict(gen_str))(),
         "cwd": gen_opt(gen_str)(),
         "size": gen_opt(
-            lambda: {
-                "rows": gen_int(),
-                "cols": gen_int(),
-            }
+            lambda: cast(
+                size_type,
+                {
+                    "rows": gen_int(),
+                    "cols": gen_int(),
+                },
+            )
         )(),
         "useReplitRunEnv": gen_opt(gen_bool)(),
         "useCgroupMagic": gen_opt(gen_bool)(),
@@ -98,22 +137,7 @@ def testShellexecSpawnInput() -> None:
 
 
 def testConmanfilesystemPersistInput() -> None:
-    x: tyd.ConmanfilesystemPersistInput = {
-        "cmd": gen_str(),
-        "args": gen_opt(gen_list(gen_str))(),
-        "initialCmd": gen_opt(gen_str)(),
-        "env": gen_opt(gen_dict(gen_str))(),
-        "cwd": gen_opt(gen_str)(),
-        "size": gen_opt(
-            lambda: {
-                "rows": gen_int(),
-                "cols": gen_int(),
-            }
-        )(),
-        "useReplitRunEnv": gen_opt(gen_bool)(),
-        "useCgroupMagic": gen_opt(gen_bool)(),
-        "interactive": gen_opt(gen_bool)(),
-    }
+    x: tyd.ConmanfilesystemPersistInput = {}
 
     baseTestPattern(
         x,

--- a/scripts/parity/gen.py
+++ b/scripts/parity/gen.py
@@ -1,0 +1,45 @@
+import random
+from typing import Callable, Optional, TypeVar
+
+A = TypeVar("A")
+
+
+def gen_char() -> str:
+    pos = random.randint(0, 26 * 2)
+    if pos < 26:
+        return chr(ord("A") + pos)
+    else:
+        return chr(ord("a") + pos - 26)
+
+
+def gen_str() -> str:
+    return "".join(gen_char() for _ in range(0, random.randint(0, 20)))
+
+
+def gen_list(gen_x: Callable[[], A]) -> Callable[[], list[A]]:
+    return lambda: [gen_x() for _ in range(0, random.randint(0, 10))]
+
+
+def gen_bool() -> bool:
+    # Ten times more likely to be true than false
+    return bool(random.randint(0, 10))
+
+
+def gen_float() -> float:
+    return random.random() * 100
+
+
+def gen_int() -> int:
+    return random.randint(0, 2048)
+
+
+def gen_choice(choices: list[A]) -> Callable[[], A]:
+    return lambda: random.choice(choices)
+
+
+def gen_opt(gen_x: Callable[[], A]) -> Callable[[], Optional[A]]:
+    return lambda: gen_x() if gen_bool() else None
+
+
+def gen_dict(gen_x: Callable[[], A]) -> Callable[[], dict[str, A]]:
+    return lambda: dict((gen_str(), gen_x()) for _ in range(0, random.randint(0, 5)))


### PR DESCRIPTION
Why
===

We got pretty close to having TypedDicts for river-python inputs before, but had to roll back due to a protocol mismatch.

Trying again, and also adding some tests to confirm that at the very least the Pydantic models can decode was was encoded by the TypedDict encoders. It's not a perfect science, but it should be good enough to start building more confidence as we make additional progress.

### The reason for "janky" tests

There's a bit of a chicken-and-egg situation when trying to test code generation at runtime.

We have three options:
- write pytest handlers where each invocation runs the codegen with a temp target (like the shell script does here), writes a static file for each text into that directory, then executes a new python into that directory. The challenge with this is that it would suck to write or maintain.
- write pytest handlers which runs the codegen with unique module name targets (like `gen1`, `gen2`, `gen3`, one for each codegen run necessary) and carefully juggle the imports to make sure we don't try to import something that's not there yet. This _might_ be the best option, but I'm not convinced about the ergonomics at the moment. It might be OK though, with highly targeted `.gitignore`'s.
- maintain a bespoke test runner, optimize for writing and maintaining these tests, and just acknowledge that we are doing something obscure and difficult.

I definitely wrote the tests here in a way that would give some coverage and also provide confidence, while intentionally deferring the above decision so we can keep making progress. in the meantime.

What changed
============

- Added some janky tests for comparing the encoding of both models
- Fixed many bugs in the TypedDict codegen and encoders

Test plan
=========

```
$ bash scripts/parity.sh
Using /tmp/river-codegen-parity.bAZ
Starting...
Verified
```
