### PR TITLE
[replit_river] close websocket right away whe closing

### DIFF
--- a/replit_river/websocket_wrapper.py
+++ b/replit_river/websocket_wrapper.py
@@ -28,8 +28,5 @@ class WebsocketWrapper:
         async with self.ws_lock:
             if self.ws_state == WsState.OPEN:
                 self.ws_state = WsState.CLOSING
-                task = asyncio.create_task(self.ws.close())
-                task.add_done_callback(
-                    lambda _: logger.debug("old websocket %s closed.", self.ws.id)
-                )
+                await self.ws.close()
                 self.ws_state = WsState.CLOSED


### PR DESCRIPTION
Why
===
* We were seeing lots of log spam at the end of test runs starting with

> Task was destroyed but it is pending!

What changed
===
* Instead of enqueuing a websocket close task while closing the websocket wrapper, immediately close the websocket

Test plan
===
* Run any e2e test in ai with this new version and see there is no longer a bunch of log spam