### PR TITLE
[websocket] use background tasks instead of cleanup function 

### DIFF
--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from typing import Any, Generic, Optional, Union
@@ -39,11 +38,10 @@ class Client(Generic[HandshakeMetadataType]):
             transport_options=transport_options,
         )
 
-    async def close(self) -> asyncio.Task | None:
+    async def close(self) -> None:
         logger.info(f"river client {self._client_id} start closing")
-        cleanup_task = await self._transport.close()
+        await self._transport.close()
         logger.info(f"river client {self._client_id} closed")
-        return cleanup_task
 
     async def ensure_connected(self) -> None:
         await self._transport.get_or_create_session()

--- a/replit_river/client_transport.py
+++ b/replit_river/client_transport.py
@@ -68,9 +68,9 @@ class ClientTransport(Transport, Generic[HandshakeMetadataType]):
         # We want to make sure there's only one session creation at a time
         self._create_session_lock = asyncio.Lock()
 
-    async def close(self) -> asyncio.Task:
+    async def close(self) -> None:
         self._rate_limiter.close()
-        return await self._close_all_sessions()
+        await self._close_all_sessions()
 
     async def get_or_create_session(self) -> ClientSession:
         async with self._create_session_lock:

--- a/replit_river/transport.py
+++ b/replit_river/transport.py
@@ -27,8 +27,7 @@ class Transport:
         self._handlers: Dict[Tuple[str, str], Tuple[str, GenericRpcHandler]] = {}
         self._session_lock = asyncio.Lock()
 
-    async def _close_all_sessions(self) -> asyncio.Task:
-        cleanup_tasks: list[asyncio.Task] = []
+    async def _close_all_sessions(self) -> None:
         sessions = self._sessions.values()
         logger.info(
             f"start closing sessions {self._transport_id}, number sessions : "
@@ -39,17 +38,9 @@ class Transport:
         # closing sessions requires access to the session lock, so we need to close
         # them one by one to be safe
         for session in sessions_to_close:
-            cleanup_task = await session.close()
-            if cleanup_task:
-                cleanup_tasks.append(cleanup_task)
+            await session.close()
 
         logger.info(f"Transport closed {self._transport_id}")
-
-        async def cleanup() -> None:
-            for cleanup_task in cleanup_tasks:
-                await cleanup_task
-
-        return asyncio.create_task(cleanup())
 
     async def _delete_session(self, session: Session) -> None:
         async with self._session_lock:

--- a/replit_river/websocket_wrapper.py
+++ b/replit_river/websocket_wrapper.py
@@ -5,6 +5,7 @@ import logging
 from websockets import WebSocketCommonProtocol
 
 logger = logging.getLogger(__name__)
+_background_tasks: set[asyncio.Task] = set()
 
 
 class WsState(enum.Enum):
@@ -29,7 +30,6 @@ class WebsocketWrapper:
             if self.ws_state == WsState.OPEN:
                 self.ws_state = WsState.CLOSING
                 task = asyncio.create_task(self.ws.close())
-                task.add_done_callback(
-                    lambda _: logger.debug("old websocket %s closed.", self.ws.id)
-                )
+                _background_tasks.add(task)
+                task.add_done_callback(_background_tasks.discard)
                 self.ws_state = WsState.CLOSED

--- a/replit_river/websocket_wrapper.py
+++ b/replit_river/websocket_wrapper.py
@@ -24,7 +24,7 @@ class WebsocketWrapper:
         async with self.ws_lock:
             return self.ws_state == WsState.OPEN
 
-    async def close(self) -> asyncio.Task | None:
+    async def close(self) -> None:
         async with self.ws_lock:
             if self.ws_state == WsState.OPEN:
                 self.ws_state = WsState.CLOSING
@@ -33,5 +33,3 @@ class WebsocketWrapper:
                     lambda _: logger.debug("old websocket %s closed.", self.ws.id)
                 )
                 self.ws_state = WsState.CLOSED
-                return task
-            return None


### PR DESCRIPTION
Why
===
* The cleanup function added a burden on the caller to make sure the
tasks were awaited.
* Instead, follow the advice of
https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
and store them in the background properly

What changed
===
* Revert cleanup commit
* Add background websocket task storage

Test plan
===
* Ran a pytest, and didn't see "Pending task destroyed" exceptions