### PR TITLE
[feat] Disable pyright checking field Pydantic field aliases

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -403,12 +403,26 @@ def encode_type(
                     if name not in type.required:
                         value = ""
                         if base_model != "TypedDict":
-                            value = f" = Field(default=None, alias='{name}')"
+                            value = dedent(
+                                f"""\
+                                = Field(
+                                  default=None,
+                                  alias='{name}', # type: ignore
+                                )
+                                """
+                            )
                         current_chunks.append(f"  kind: Optional[{type_name}]{value}")
                     else:
                         value = ""
                         if base_model != "TypedDict":
-                            value = f" = Field({field_value}, alias='{name}')"
+                            value = dedent(
+                                f"""\
+                                = Field(
+                                    {field_value},
+                                    alias='{name}', # type: ignore
+                                )
+                                """
+                            )
                         current_chunks.append(f"  kind: {type_name}{value}")
                 else:
                     if name not in type.required:


### PR DESCRIPTION
Why
===

If we ignore the alias field, we can use pyright to typecheck python generated clients.

What changed
============

Reflow the field assignment to permit ignoring type aliases like `alias="$kind"`

Test plan
=========

Manually ran against production services, typechecked OK