### PR TITLE
[bug] Allow "undefined" like if it was its "null" brethren

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -302,7 +302,7 @@ def encode_type(
         elif type.type == "boolean":
             typeddict_encoder.append("x")
             return ("bool", ())
-        elif type.type == "null":
+        elif type.type == "null" or type.type == "undefined":
             typeddict_encoder.append("None")
             return ("None", ())
         elif type.type == "Date":


### PR DESCRIPTION
Why
===

JavaScript likes to have nullish types. We have `null` already, but we missed `undefined`.

What changed
============

This change allows `undefined` to be defined.

Test plan
=========

Codegen gen'd!