### PR TITLE
[bug/client codegen] local_discriminator should be stable

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -193,7 +193,7 @@ def encode_type(
                             """.strip()
                             )
                             if local_discriminators:
-                                local_discriminator = local_discriminators.pop()
+                                local_discriminator = sorted(local_discriminators).pop()
                             else:
                                 local_discriminator = "FIXME: Ambiguous discriminators"
                             typeddict_encoder.append(


### PR DESCRIPTION
What changed and Why
===

When there are multiple discriminator choices, we should just choose the first one.

Test plan
=========

Manual verification via repl