### PR TITLE
[chore] Fix uv publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Build and publish
       run: |
-        uv sync --locked
+        uv sync --frozen  # NB: Not --locked, since bumping the version changes the lockfile.
         uv build
         UV_PUBLISH_TOKEN="${{ secrets.PYPI_TOKEN }}" \
         uv publish

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,4 +1,0 @@
-[virtualenvs]
-# Ensure everyone uses the same venv location to ease debugging.
-# Makes each project more hermetic within the mono-repo.
-in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,19 @@ authors = [{ name = "Replit", email = "eng@replit.com" }]
 license = { file = "LICENSE" }
 keywords = ["rpc", "websockets"]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<4"
+classifiers = [
+  "Development Status :: 4 - Beta",
+
+  "Intended Audience :: Developers",
+  "Topic :: Internet",
+
+  "License :: OSI Approved :: MIT License",
+
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
 dependencies = [
 	"pydantic==2.9.2",
     "aiochannel>=1.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.11"
+requires-python = ">=3.11, <4"
 resolution-markers = [
     "python_full_version < '3.13'",
     "python_full_version >= '3.13'",


### PR DESCRIPTION
Why
===

I missed the significance of `--locked` vs `--frozen` when setting up for publishing.

What changed
============

- Using `--frozen` to _verify_ `uv.lock` but permit metadata changes (like the package `version` that gets updated prior to publishing)
- Adding missing package classifiers

Test plan
=========

Can we publish? Can we install? Does the installed package work?