### PR TITLE
Upgrade protobuf dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-	"pydantic==2.9.2",
+    "pydantic==2.9.2",
     "aiochannel>=1.2.1",
     "black>=23.11,<25.0",
     "grpcio-tools>=1.59.3",
@@ -28,7 +28,7 @@ dependencies = [
     "msgpack-types>=0.3.0",
     "msgpack>=1.0.7",
     "nanoid>=2.0.0",
-    "protobuf>=4.24.4",
+    "protobuf>=5.28.3",
     "pydantic-core>=2.20.1",
     "websockets>=12.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -543,7 +543,7 @@ requires-dist = [
     { name = "msgpack", specifier = ">=1.0.7" },
     { name = "msgpack-types", specifier = ">=0.3.0" },
     { name = "nanoid", specifier = ">=2.0.0" },
-    { name = "protobuf", specifier = ">=4.24.4" },
+    { name = "protobuf", specifier = ">=5.28.3" },
     { name = "pydantic", specifier = "==2.9.2" },
     { name = "pydantic-core", specifier = ">=2.20.1" },
     { name = "websockets", specifier = ">=12.0" },


### PR DESCRIPTION
Why
===

The rest of the python ecosystem is on protobuf 5, let's upgrade so we aren't stuck with old dependencies.

What changed
============

- Upgrade protobuf to v5

Test plan
=========

- Codegen should still work

