### PR TITLE
Missing some signatures from #111

### DIFF
--- a/replit_river/rpc.py
+++ b/replit_river/rpc.py
@@ -9,6 +9,7 @@ from typing import (
     Dict,
     Generic,
     Iterable,
+    Iterator,
     Literal,
     Mapping,
     NoReturn,
@@ -311,7 +312,7 @@ def subscription_method_handler(
 
 def upload_method_handler(
     method: Callable[
-        [AsyncIterator[RequestType], grpc.aio.ServicerContext],
+        [Iterator[RequestType] | AsyncIterator[RequestType], grpc.aio.ServicerContext],
         ResponseType | Awaitable[ResponseType],
     ],
     request_deserializer: Callable[[Any], RequestType],
@@ -388,7 +389,7 @@ def upload_method_handler(
 
 def stream_method_handler(
     method: Callable[
-        [AsyncIterator[RequestType], grpc.aio.ServicerContext],
+        [Iterator[RequestType] | AsyncIterator[RequestType], grpc.aio.ServicerContext],
         AsyncIterable[ResponseType],
     ],
     request_deserializer: Callable[[Any], RequestType],


### PR DESCRIPTION
Why
===

I handled the output types, but not the input types.

This is arguably more onerous for server implementations, but this still does conform to how grpc server codegen types work today.

What changed
============

For lack of a stable way to say "I will be providing you an `AsyncIterator[RequestType]`, I don't care if you take other types as well" we should at the very least conform to the type signature exposed by grpc codegen.

Test plan
=========

Does bumping this library cause existing modules to typecheck correctly?