### PR TITLE
bug/minor oddities

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Repl.it
+Copyright (c) 2024 Replit
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -877,10 +877,6 @@ def generate_individual_service(
                             lambda x: TypeAdapter({render_type_expr(input_type)})
                               .validate_python
             """
-        if isinstance(
-            procedure.init, RiverConcreteType
-        ) and procedure.init.type not in ["object", "array"]:
-            render_init_method = "lambda x: x"
 
         assert (
             render_init_method

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -922,10 +922,6 @@ def generate_individual_service(
             parse_output_method = "lambda x: None"
 
         if procedure.type == "rpc":
-            control_flow_keyword = "return "
-            if output_type == "None":
-                control_flow_keyword = ""
-
             current_chunks.extend(
                 [
                     reindent(
@@ -935,7 +931,7 @@ def generate_individual_service(
               self,
               input: {render_type_expr(input_type)},
             ) -> {render_type_expr(output_type)}:
-              {control_flow_keyword}await self.client.send_rpc(
+              return await self.client.send_rpc(
                 {repr(schema_name)},
                 {repr(name)},
                 input,
@@ -970,9 +966,6 @@ def generate_individual_service(
                 ]
             )
         elif procedure.type == "upload":
-            control_flow_keyword = "return "
-            if output_type == "None":
-                control_flow_keyword = ""
             if init_type:
                 assert render_init_method, "Expected an init renderer!"
                 current_chunks.extend(
@@ -985,7 +978,7 @@ def generate_individual_service(
               init: {init_type},
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> {output_type}:
-              {control_flow_keyword}await self.client.send_upload(
+              return await self.client.send_upload(
                 {repr(schema_name)},
                 {repr(name)},
                 init,
@@ -1009,7 +1002,7 @@ def generate_individual_service(
               self,
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> {render_type_expr(output_or_error_type)}:
-              {control_flow_keyword}await self.client.send_upload(
+              return await self.client.send_upload(
                 {repr(schema_name)},
                 {repr(name)},
                 None,


### PR DESCRIPTION
Why
===

None of these changes impact production codepaths, so we've presumably been skating by without issue up until now, but let's make sure we don't run into trouble in the future.

What changed
============

- `f"x: '{foo}'` -> `f"x: {repr(foo)}"`. If it's a string, it'll be a no-op. If it's not, it'll be an error.
- `RiverNotType` has never worked. Rip it out.
- Address incorrect `init` vs `input` bindings
- The result type of transport messages will be `None` in the case where the whole function also should return `None`, so remove some confusing metaprogramming about optional `return` statements.

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
