### PR TITLE
bugfix: Ensure both trace fields are set if tracing is used

### DIFF
--- a/replit_river/rpc.py
+++ b/replit_river/rpc.py
@@ -88,8 +88,8 @@ class ControlMessageHandshakeResponse(BaseModel):
 
 
 class PropagationContext(BaseModel):
-    traceparent: Optional[str] = None
-    tracestate: Optional[str] = None
+    traceparent: str = Field(default="")
+    tracestate: str = Field(default="")
 
 
 class TransportMessage(BaseModel):


### PR DESCRIPTION
Why
===

If `tracing` is set, we expect `traceparent` and `tracestate` to be non-null on the server side. If there is no tracestate, an empty string is sufficient.

What changed
============

- Default `traceparent` and `tracestate` to empty strings

Test plan
=========

- Tracing should work without the TS server rejecting these messages
