### PR TITLE
Revert "Turns out pydantic has never been able to correctly discern a RiverNotType"

### DIFF
--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent, indent
 from typing import (
+    Any,
     Dict,
     List,
     Literal,
@@ -179,7 +180,15 @@ class RiverIntersectionType(BaseModel):
     allOf: List["RiverType"]
 
 
-RiverType = Union[RiverConcreteType, RiverUnionType, RiverIntersectionType]
+class RiverNotType(BaseModel):
+    """This is used to represent void / never."""
+
+    not_: Any = Field(..., alias="not")
+
+
+RiverType = Union[
+    RiverConcreteType, RiverUnionType, RiverNotType, RiverIntersectionType
+]
 
 
 class RiverProcedure(BaseModel):
@@ -230,7 +239,9 @@ def encode_type(
 ) -> Tuple[TypeExpression, list[ModuleName], list[FileContents], set[TypeName]]:
     encoder_name: Optional[str] = None  # defining this up here to placate mypy
     chunks: List[FileContents] = []
-    if isinstance(type, RiverUnionType):
+    if isinstance(type, RiverNotType):
+        return (TypeName("None"), [], [], set())
+    elif isinstance(type, RiverUnionType):
         typeddict_encoder = list[str]()
         encoder_names: set[TypeName] = set()
 
@@ -476,8 +487,6 @@ def encode_type(
             # Handle the case where type is not specified
             typeddict_encoder.append("x")
             return (TypeName("Any"), [], [], set())
-        elif type.type == "not":
-            return (TypeName("None"), [], [], set())
         elif type.type == "string":
             if type.const:
                 typeddict_encoder.append(repr(type.const))
@@ -566,7 +575,9 @@ def encode_type(
                 encoder_name = None
                 chunks.extend(contents)
                 if base_model == "TypedDict":
-                    if isinstance(prop, RiverUnionType):
+                    if isinstance(prop, RiverNotType):
+                        typeddict_encoder.append("'not implemented'")
+                    elif isinstance(prop, RiverUnionType):
                         encoder_name = TypeName(
                             f"encode_{ensure_literal_type(type_name)}"
                         )
@@ -585,9 +596,7 @@ def encode_type(
                             safe_name = "kind"
                         else:
                             safe_name = name
-                        if prop.type == "not":
-                            typeddict_encoder.append("'not implemented'")
-                        elif prop.type == "object" and not prop.patternProperties:
+                        if prop.type == "object" and not prop.patternProperties:
                             encoder_name = TypeName(
                                 f"encode_{ensure_literal_type(type_name)}"
                             )


### PR DESCRIPTION
Why
===

Whoops, turns out it _did_ work, just not the way I thought it did.

What changed
============

This reverts commit f3bbfb9513792def2681fda0def872dc0c5e3f24.

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
