### PR TITLE
bugfix: make streaming spans last for the entire duration of the stream

### DIFF
--- a/replit_river/client.py
+++ b/replit_river/client.py
@@ -106,14 +106,15 @@ class Client(Generic[HandshakeMetadataType]):
     ) -> AsyncIterator[Union[ResponseType, ErrorType]]:
         with _trace_procedure("subscription", service_name, procedure_name):
             session = await self._transport.get_or_create_session()
-            return session.send_subscription(
+            async for msg in session.send_subscription(
                 service_name,
                 procedure_name,
                 request,
                 request_serializer,
                 response_deserializer,
                 error_deserializer,
-            )
+            ):
+                yield msg
 
     async def send_stream(
         self,
@@ -128,7 +129,7 @@ class Client(Generic[HandshakeMetadataType]):
     ) -> AsyncIterator[Union[ResponseType, ErrorType]]:
         with _trace_procedure("stream", service_name, procedure_name):
             session = await self._transport.get_or_create_session()
-            return session.send_stream(
+            async for msg in session.send_stream(
                 service_name,
                 procedure_name,
                 init,
@@ -137,7 +138,8 @@ class Client(Generic[HandshakeMetadataType]):
                 request_serializer,
                 response_deserializer,
                 error_deserializer,
-            )
+            ):
+                yield msg
 
 
 @contextmanager

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -978,7 +978,7 @@ def generate_individual_service(
               init: {init_type},
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> {output_type}:
-              return self.client.send_upload(
+              return await self.client.send_upload(
                 {repr(schema_name)},
                 {repr(name)},
                 init,
@@ -1002,7 +1002,7 @@ def generate_individual_service(
               self,
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> {render_type_expr(output_or_error_type)}:
-              return self.client.send_upload(
+              return await self.client.send_upload(
                 {repr(schema_name)},
                 {repr(name)},
                 None,

--- a/replit_river/codegen/client.py
+++ b/replit_river/codegen/client.py
@@ -953,7 +953,7 @@ def generate_individual_service(
               self,
               input: {render_type_expr(input_type)},
             ) -> AsyncIterator[{render_type_expr(output_or_error_type)}]:
-              return await self.client.send_subscription(
+              return self.client.send_subscription(
                 {repr(schema_name)},
                 {repr(name)},
                 input,
@@ -978,7 +978,7 @@ def generate_individual_service(
               init: {init_type},
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> {output_type}:
-              return await self.client.send_upload(
+              return self.client.send_upload(
                 {repr(schema_name)},
                 {repr(name)},
                 init,
@@ -1002,7 +1002,7 @@ def generate_individual_service(
               self,
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> {render_type_expr(output_or_error_type)}:
-              return await self.client.send_upload(
+              return self.client.send_upload(
                 {repr(schema_name)},
                 {repr(name)},
                 None,
@@ -1029,7 +1029,7 @@ def generate_individual_service(
               init: {render_type_expr(init_type)},
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> AsyncIterator[{render_type_expr(output_or_error_type)}]:
-              return await self.client.send_stream(
+              return self.client.send_stream(
                 {repr(schema_name)},
                 {repr(name)},
                 init,
@@ -1053,7 +1053,7 @@ def generate_individual_service(
               self,
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> AsyncIterator[{render_type_expr(output_or_error_type)}]:
-              return await self.client.send_stream(
+              return self.client.send_stream(
                 {repr(schema_name)},
                 {repr(name)},
                 None,

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -37,8 +37,8 @@ async def test_upload_method(client: Client) -> None:
         serialize_request,
         serialize_request,
         deserialize_response,
-        deserialize_response,
-    )  # type: ignore
+        deserialize_error,
+    )
     assert response == "Uploaded: Initial Data, Data 1, Data 2, Data 3"
 
 
@@ -58,8 +58,8 @@ async def test_upload_more_than_send_buffer_max(client: Client) -> None:
         serialize_request,
         serialize_request,
         deserialize_response,
-        deserialize_response,
-    )  # type: ignore
+        deserialize_error,
+    )
     assert response == "Uploaded: Initial Data" + (", Data" * iterations)
 
 
@@ -77,8 +77,8 @@ async def test_upload_empty(client: Client) -> None:
         None,
         serialize_request,
         deserialize_response,
-        deserialize_response,
-    )  # type: ignore
+        deserialize_error,
+    )
     assert response == "Uploaded: "
 
 
@@ -92,6 +92,7 @@ async def test_subscription_method(client: Client) -> None:
         deserialize_response,
         deserialize_error,
     ):
+        assert isinstance(response, str)
         assert "Subscription message" in response
 
 

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -84,7 +84,7 @@ async def test_upload_empty(client: Client) -> None:
 
 @pytest.mark.asyncio
 async def test_subscription_method(client: Client) -> None:
-    async for response in await client.send_subscription(
+    async for response in client.send_subscription(
         "test_service",
         "subscription_method",
         "Bob",
@@ -103,7 +103,7 @@ async def test_stream_method(client: Client) -> None:
         yield "Stream 3"
 
     responses = []
-    async for response in await client.send_stream(
+    async for response in client.send_stream(
         "test_service",
         "stream_method",
         "Initial Stream Data",
@@ -130,7 +130,7 @@ async def test_stream_empty(client: Client) -> None:
             yield "unreachable"
 
     responses = []
-    async for response in await client.send_stream(
+    async for response in client.send_stream(
         "test_service",
         "stream_method",
         None,
@@ -167,7 +167,7 @@ async def test_multiplexing(client: Client) -> None:
             deserialize_error,
         )
     )
-    stream_task = await client.send_stream(
+    stream_task = client.send_stream(
         "test_service",
         "stream_method",
         "Initial Stream Data",


### PR DESCRIPTION
Why
===

The streaming spans were immediately finishing because we were only tracing the construction of the `AsyncIterator` and not the full iteration.

What changed
============

- loop and yield each message of the streaming procedures so the span doesn't finish until the async iterator is disposed.

Test plan
=========

- Streaming procedure spans should now last the full duration of the stream procedure
