### PR TITLE
bugfix: include streaming procedure errors in traces

### DIFF
--- a/replit_river/session.py
+++ b/replit_river/session.py
@@ -38,6 +38,9 @@ from .rpc import (
 
 logger = logging.getLogger(__name__)
 
+trace_propagator = TraceContextTextMapPropagator()
+trace_setter = TransportMessageTracingSetter()
+
 
 class SessionState(enum.Enum):
     """The state a session can be in.
@@ -386,9 +389,7 @@ class Session(object):
         )
         if span:
             with use_span(span):
-                TraceContextTextMapPropagator().inject(
-                    msg, None, TransportMessageTracingSetter()
-                )
+                trace_propagator.inject(msg, None, trace_setter)
         try:
             # We need this lock to ensure the buffer order and message sending order
             # are the same.

--- a/tests/river_fixtures/logging.py
+++ b/tests/river_fixtures/logging.py
@@ -15,8 +15,15 @@ class NoErrors:
 
     def __init__(self, caplog: LogCaptureFixture):
         self.caplog = caplog
+        self._allow_errors = False
+
+    def allow_errors(self) -> None:
+        self._allow_errors = True
 
     def __call__(self) -> None:
+        if self._allow_errors:
+            return
+
         assert len(self.caplog.get_records("setup")) == 0
         assert len(self.caplog.get_records("call")) == 0
         assert len(self.caplog.get_records("teardown")) == 0

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -18,7 +18,7 @@ async def test_rpc_method(client: Client) -> None:
         serialize_request,
         deserialize_response,
         deserialize_error,
-    )  # type: ignore
+    )
     assert response == "Hello, Alice!"
 
 

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -1,0 +1,143 @@
+from typing import AsyncGenerator
+
+import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+from replit_river.client import Client
+from replit_river.error_schema import RiverError
+from tests.conftest import deserialize_error, deserialize_response, serialize_request
+from tests.river_fixtures.logging import NoErrors
+
+
+@pytest.mark.asyncio
+async def test_rpc_method_span(
+    client: Client, span_exporter: InMemorySpanExporter
+) -> None:
+    response = await client.send_rpc(
+        "test_service",
+        "rpc_method",
+        "Alice",
+        serialize_request,
+        deserialize_response,
+        deserialize_error,
+    )
+    assert response == "Hello, Alice!"
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "river.client.rpc.test_service.rpc_method"
+
+
+@pytest.mark.asyncio
+async def test_upload_method_span(
+    client: Client, span_exporter: InMemorySpanExporter
+) -> None:
+    async def upload_data() -> AsyncGenerator[str, None]:
+        yield "Data 1"
+        yield "Data 2"
+        yield "Data 3"
+
+    response = await client.send_upload(
+        "test_service",
+        "upload_method",
+        "Initial Data",
+        upload_data(),
+        serialize_request,
+        serialize_request,
+        deserialize_response,
+        deserialize_error,
+    )
+    assert response == "Uploaded: Initial Data, Data 1, Data 2, Data 3"
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "river.client.upload.test_service.upload_method"
+
+
+@pytest.mark.asyncio
+async def test_subscription_method_span(
+    client: Client, span_exporter: InMemorySpanExporter
+) -> None:
+    async for response in client.send_subscription(
+        "test_service",
+        "subscription_method",
+        "Bob",
+        serialize_request,
+        deserialize_response,
+        deserialize_error,
+    ):
+        assert isinstance(response, str)
+        assert "Subscription message" in response
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "river.client.subscription.test_service.subscription_method"
+
+
+@pytest.mark.asyncio
+async def test_stream_method_span(
+    client: Client, span_exporter: InMemorySpanExporter
+) -> None:
+    async def stream_data() -> AsyncGenerator[str, None]:
+        yield "Stream 1"
+        yield "Stream 2"
+        yield "Stream 3"
+
+    responses = []
+    async for response in client.send_stream(
+        "test_service",
+        "stream_method",
+        "Initial Stream Data",
+        stream_data(),
+        serialize_request,
+        serialize_request,
+        deserialize_response,
+        deserialize_error,
+    ):
+        responses.append(response)
+
+    assert responses == [
+        "Stream response for Initial Stream Data",
+        "Stream response for Stream 1",
+        "Stream response for Stream 2",
+        "Stream response for Stream 3",
+    ]
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "river.client.stream.test_service.stream_method"
+
+
+@pytest.mark.asyncio
+async def test_stream_error_method_span(
+    client: Client,
+    span_exporter: InMemorySpanExporter,
+    no_logging_error: NoErrors,
+) -> None:
+    # We are explicitly testing errors.
+    no_logging_error.allow_errors()
+
+    async def stream_data() -> AsyncGenerator[str, None]:
+        yield "Stream 1"
+        yield "Stream 2"
+        yield "Stream 3"
+
+    responses = []
+    async for response in client.send_stream(
+        "test_service",
+        "stream_method_error",
+        "Initial Stream Data",
+        stream_data(),
+        serialize_request,
+        serialize_request,
+        deserialize_response,
+        deserialize_error,
+    ):
+        responses.append(response)
+
+    assert len(responses) == 1
+    assert isinstance(responses[0], RiverError)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "river.client.stream.test_service.stream_method_error"
+    assert spans[0].status.status_code == StatusCode.ERROR


### PR DESCRIPTION
Why
===

Streaming response procedures don't raise errors like the other procedures, instead the errors are included in the `AsyncIterator`.

Also fixes issues with using contextvars + async generators.

What changed
============

- Check if the message from the async iterator is a `RiverError`, if so, record it on the span
- Use `start_span` instead of `start_as_current_span`, the latter resets a contextvar in its `finally` clause which is invalid to do for async generators as the async generator's finalizers run in a different context
    - Thread the span through manually so we still propagate the tracing info

Test plan
=========

- Should see errors for failed streaming procedures
- Logs about resetting contextvars in a different context should go away
- Added some tests for the otel stuff to make sure the error handling works here
