### PR TITLE
use empty context in restore budget task

### DIFF
--- a/replit_river/rate_limiter.py
+++ b/replit_river/rate_limiter.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+from contextvars import Context
 from typing import Dict
 
 from replit_river.transport_options import ConnectionRetryOptions
@@ -83,7 +84,9 @@ class LeakyBucketRateLimit:
         Args:
             user (str): The identifier for the user.
         """
-        self.tasks[user] = asyncio.create_task(self.restore_budget(user))
+        self.tasks[user] = asyncio.create_task(
+            self.restore_budget(user), context=Context()
+        )
 
     async def restore_budget(self, user: str) -> None:
         """Asynchronously wait for the interval and then restore the budget for the


### PR DESCRIPTION
Why
===

By default, new asyncio tasks hold onto a reference to the current context. If the user of river has a lot of data in the context while the restore budget task is created, that context cannot be GC'd until the task exits. This can lead to accidental memory leaks.

As a followup we will replace this rate limiter with one that does not require background tasks.

What changed
============

- Create a fresh context for restore budget task

Test plan
=========

- Shouldn't have any behavior impact here, we don't rely on the context for budget restoration.
- We should see fewer memory leaks internally

