### PR TITLE
[tests] handler decomposition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev-dependencies = [
     "pytest-mock>=3.11.1",
     "ruff>=0.0.278",
     "types-protobuf>=4.24.0.20240311",
+    "types-nanoid>=2.0.0.20240601",
 ]
 
 [tool.ruff]

--- a/tests/common_handlers.py
+++ b/tests/common_handlers.py
@@ -1,0 +1,82 @@
+from typing import Any, AsyncGenerator, AsyncIterator, Iterator
+
+import grpc
+import grpc.aio
+
+from replit_river.rpc import (
+    rpc_method_handler,
+    stream_method_handler,
+    subscription_method_handler,
+    upload_method_handler,
+)
+from tests.conftest import HandlerMapping, deserialize_request, serialize_response
+
+
+async def rpc_handler(request: str, context: grpc.aio.ServicerContext) -> str:
+    return f"Hello, {request}!"
+
+
+basic_rpc_method: HandlerMapping = {
+    ("test_service", "rpc_method"): (
+        "rpc",
+        rpc_method_handler(rpc_handler, deserialize_request, serialize_response),
+    )
+}
+
+
+async def upload_handler(
+    request: Iterator[str] | AsyncIterator[str], context: Any
+) -> str:
+    uploaded_data = []
+    if isinstance(request, AsyncIterator):
+        async for data in request:
+            uploaded_data.append(data)
+    else:
+        for data in request:
+            uploaded_data.append(data)
+    return f"Uploaded: {', '.join(uploaded_data)}"
+
+
+basic_upload: HandlerMapping = {
+    ("test_service", "upload_method"): (
+        "upload",
+        upload_method_handler(upload_handler, deserialize_request, serialize_response),
+    ),
+}
+
+
+async def subscription_handler(
+    request: str, context: grpc.aio.ServicerContext
+) -> AsyncGenerator[str, None]:
+    for i in range(5):
+        yield f"Subscription message {i} for {request}"
+
+
+basic_subscription: HandlerMapping = {
+    ("test_service", "subscription_method"): (
+        "subscription",
+        subscription_method_handler(
+            subscription_handler, deserialize_request, serialize_response
+        ),
+    ),
+}
+
+
+async def stream_handler(
+    request: Iterator[str] | AsyncIterator[str],
+    context: grpc.aio.ServicerContext,
+) -> AsyncGenerator[str, None]:
+    if isinstance(request, AsyncIterator):
+        async for data in request:
+            yield f"Stream response for {data}"
+    else:
+        for data in request:
+            yield f"Stream response for {data}"
+
+
+basic_stream: HandlerMapping = {
+    ("test_service", "stream_method"): (
+        "stream",
+        stream_method_handler(stream_handler, deserialize_request, serialize_response),
+    ),
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,9 +153,16 @@ def transport_options() -> TransportOptions:
 
 
 @pytest.fixture
-def server(transport_options: TransportOptions) -> Server:
+def server_handlers(handlers: HandlerMapping) -> HandlerMapping:
+    return handlers
+
+
+@pytest.fixture
+def server(
+    transport_options: TransportOptions, server_handlers: HandlerMapping
+) -> Server:
     server = Server(server_id="test_server", transport_options=transport_options)
-    server.add_rpc_handlers(common_handlers)
+    server.add_rpc_handlers(server_handlers)
     return server
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,8 @@
 import asyncio
 import logging
-from collections.abc import AsyncIterator
-from typing import Any, AsyncGenerator, Iterator, Literal, Mapping
+from typing import Any, AsyncGenerator, Literal, Mapping
 
-import grpc.aio
-import nanoid  # type: ignore
+import nanoid
 import pytest
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -14,14 +12,10 @@ from websockets.server import serve
 
 from replit_river.client import Client
 from replit_river.client_transport import UriAndMetadata
-from replit_river.error_schema import RiverError, RiverException
+from replit_river.error_schema import RiverError
 from replit_river.rpc import (
     GenericRpcHandler,
     TransportMessage,
-    rpc_method_handler,
-    stream_method_handler,
-    subscription_method_handler,
-    upload_method_handler,
 )
 from replit_river.server import Server
 from replit_river.transport_options import TransportOptions
@@ -72,79 +66,6 @@ def deserialize_response(response: dict) -> str:
 
 def deserialize_error(response: dict) -> RiverError:
     return RiverError.model_validate(response)
-
-
-# RPC method handlers for testing
-async def rpc_handler(request: str, context: grpc.aio.ServicerContext) -> str:
-    return f"Hello, {request}!"
-
-
-async def subscription_handler(
-    request: str, context: grpc.aio.ServicerContext
-) -> AsyncGenerator[str, None]:
-    for i in range(5):
-        yield f"Subscription message {i} for {request}"
-
-
-async def upload_handler(
-    request: Iterator[str] | AsyncIterator[str], context: Any
-) -> str:
-    uploaded_data = []
-    if isinstance(request, AsyncIterator):
-        async for data in request:
-            uploaded_data.append(data)
-    else:
-        for data in request:
-            uploaded_data.append(data)
-    return f"Uploaded: {', '.join(uploaded_data)}"
-
-
-async def stream_handler(
-    request: Iterator[str] | AsyncIterator[str],
-    context: grpc.aio.ServicerContext,
-) -> AsyncGenerator[str, None]:
-    if isinstance(request, AsyncIterator):
-        async for data in request:
-            yield f"Stream response for {data}"
-    else:
-        for data in request:
-            yield f"Stream response for {data}"
-
-
-async def stream_error_handler(
-    request: Iterator[str] | AsyncIterator[str],
-    context: grpc.aio.ServicerContext,
-) -> AsyncGenerator[str, None]:
-    raise RiverException("INJECTED_ERROR", "test error")
-    yield "test"  # appease the type checker
-
-
-common_handlers: HandlerMapping = {
-    ("test_service", "rpc_method"): (
-        "rpc",
-        rpc_method_handler(rpc_handler, deserialize_request, serialize_response),
-    ),
-    ("test_service", "subscription_method"): (
-        "subscription",
-        subscription_method_handler(
-            subscription_handler, deserialize_request, serialize_response
-        ),
-    ),
-    ("test_service", "upload_method"): (
-        "upload",
-        upload_method_handler(upload_handler, deserialize_request, serialize_response),
-    ),
-    ("test_service", "stream_method"): (
-        "stream",
-        stream_method_handler(stream_handler, deserialize_request, serialize_response),
-    ),
-    ("test_service", "stream_method_error"): (
-        "stream",
-        stream_method_handler(
-            stream_error_handler, deserialize_request, serialize_response
-        ),
-    ),
-}
 
 
 @pytest.fixture

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -6,10 +6,11 @@ import pytest
 from replit_river.client import Client
 from replit_river.error_schema import RiverError
 from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE
-from tests.conftest import deserialize_error, deserialize_response, serialize_request
+from tests.conftest import common_handlers, deserialize_error, deserialize_response, serialize_request
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_rpc_method(client: Client) -> None:
     response = await client.send_rpc(
         "test_service",
@@ -23,6 +24,7 @@ async def test_rpc_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_upload_method(client: Client) -> None:
     async def upload_data() -> AsyncGenerator[str, None]:
         yield "Data 1"
@@ -43,6 +45,7 @@ async def test_upload_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_upload_more_than_send_buffer_max(client: Client) -> None:
     iterations = MAX_MESSAGE_BUFFER_SIZE * 2
 
@@ -64,6 +67,7 @@ async def test_upload_more_than_send_buffer_max(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_upload_empty(client: Client) -> None:
     async def upload_data(enabled: bool = False) -> AsyncGenerator[str, None]:
         if enabled:
@@ -83,6 +87,7 @@ async def test_upload_empty(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_subscription_method(client: Client) -> None:
     async for response in client.send_subscription(
         "test_service",
@@ -97,6 +102,7 @@ async def test_subscription_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_stream_method(client: Client) -> None:
     async def stream_data() -> AsyncGenerator[str, None]:
         yield "Stream 1"
@@ -125,6 +131,7 @@ async def test_stream_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_stream_empty(client: Client) -> None:
     async def stream_data(enabled: bool = False) -> AsyncGenerator[str, None]:
         if enabled:
@@ -147,6 +154,7 @@ async def test_stream_empty(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_multiplexing(client: Client) -> None:
     async def upload_data() -> AsyncGenerator[str, None]:
         yield "Upload Data 1"

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -6,11 +6,21 @@ import pytest
 from replit_river.client import Client
 from replit_river.error_schema import RiverError
 from replit_river.transport_options import MAX_MESSAGE_BUFFER_SIZE
-from tests.conftest import common_handlers, deserialize_error, deserialize_response, serialize_request
+from tests.common_handlers import (
+    basic_rpc_method,
+    basic_stream,
+    basic_subscription,
+    basic_upload,
+)
+from tests.conftest import (
+    deserialize_error,
+    deserialize_response,
+    serialize_request,
+)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_rpc_method}])
 async def test_rpc_method(client: Client) -> None:
     response = await client.send_rpc(
         "test_service",
@@ -24,7 +34,7 @@ async def test_rpc_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_upload}])
 async def test_upload_method(client: Client) -> None:
     async def upload_data() -> AsyncGenerator[str, None]:
         yield "Data 1"
@@ -45,7 +55,7 @@ async def test_upload_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_upload}])
 async def test_upload_more_than_send_buffer_max(client: Client) -> None:
     iterations = MAX_MESSAGE_BUFFER_SIZE * 2
 
@@ -67,7 +77,7 @@ async def test_upload_more_than_send_buffer_max(client: Client) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_upload}])
 async def test_upload_empty(client: Client) -> None:
     async def upload_data(enabled: bool = False) -> AsyncGenerator[str, None]:
         if enabled:
@@ -87,7 +97,7 @@ async def test_upload_empty(client: Client) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_subscription}])
 async def test_subscription_method(client: Client) -> None:
     async for response in client.send_subscription(
         "test_service",
@@ -102,7 +112,7 @@ async def test_subscription_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_stream}])
 async def test_stream_method(client: Client) -> None:
     async def stream_data() -> AsyncGenerator[str, None]:
         yield "Stream 1"
@@ -131,7 +141,7 @@ async def test_stream_method(client: Client) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_stream}])
 async def test_stream_empty(client: Client) -> None:
     async def stream_data(enabled: bool = False) -> AsyncGenerator[str, None]:
         if enabled:
@@ -154,7 +164,7 @@ async def test_stream_empty(client: Client) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_upload, **basic_stream}])
 async def test_multiplexing(client: Client) -> None:
     async def upload_data() -> AsyncGenerator[str, None]:
         yield "Upload Data 1"

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -7,6 +7,7 @@ from websockets.server import serve
 
 from replit_river.server import Server
 from replit_river.transport_options import TransportOptions
+from tests.conftest import common_handlers
 
 
 @pytest.fixture
@@ -15,6 +16,7 @@ def transport_options() -> TransportOptions:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_handshake_timeout(server: Server) -> None:
     async with serve(server.serve, "localhost", 8765):
         start = time()

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -7,7 +7,6 @@ from websockets.server import serve
 
 from replit_river.server import Server
 from replit_river.transport_options import TransportOptions
-from tests.conftest import common_handlers
 
 
 @pytest.fixture
@@ -16,7 +15,7 @@ def transport_options() -> TransportOptions:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{}])
 async def test_handshake_timeout(server: Server) -> None:
     async with serve(server.serve, "localhost", 8765):
         start = time()

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -1,17 +1,33 @@
-from typing import AsyncGenerator
+from typing import AsyncGenerator, AsyncIterator, Iterator
 
+import grpc
+import grpc.aio
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode
 
 from replit_river.client import Client
-from replit_river.error_schema import RiverError
-from tests.conftest import common_handlers, deserialize_error, deserialize_response, serialize_request
+from replit_river.error_schema import RiverError, RiverException
+from replit_river.rpc import stream_method_handler
+from tests.common_handlers import (
+    basic_rpc_method,
+    basic_stream,
+    basic_subscription,
+    basic_upload,
+)
+from tests.conftest import (
+    HandlerMapping,
+    deserialize_error,
+    deserialize_request,
+    deserialize_response,
+    serialize_request,
+    serialize_response,
+)
 from tests.river_fixtures.logging import NoErrors
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_rpc_method}])
 async def test_rpc_method_span(
     client: Client, span_exporter: InMemorySpanExporter
 ) -> None:
@@ -30,7 +46,7 @@ async def test_rpc_method_span(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_upload}])
 async def test_upload_method_span(
     client: Client, span_exporter: InMemorySpanExporter
 ) -> None:
@@ -56,7 +72,7 @@ async def test_upload_method_span(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_subscription}])
 async def test_subscription_method_span(
     client: Client, span_exporter: InMemorySpanExporter
 ) -> None:
@@ -77,7 +93,7 @@ async def test_subscription_method_span(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**basic_stream}])
 async def test_stream_method_span(
     client: Client, span_exporter: InMemorySpanExporter
 ) -> None:
@@ -111,8 +127,26 @@ async def test_stream_method_span(
     assert spans[0].name == "river.client.stream.test_service.stream_method"
 
 
+async def stream_error_handler(
+    request: Iterator[str] | AsyncIterator[str],
+    context: grpc.aio.ServicerContext,
+) -> AsyncGenerator[str, None]:
+    raise RiverException("INJECTED_ERROR", "test error")
+    yield "test"  # appease the type checker
+
+
+stream_error_method_handlers: HandlerMapping = {
+    ("test_service", "stream_method_error"): (
+        "stream",
+        stream_method_handler(
+            stream_error_handler, deserialize_request, serialize_response
+        ),
+    )
+}
+
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handlers", [common_handlers])
+@pytest.mark.parametrize("handlers", [{**stream_error_method_handlers}])
 async def test_stream_error_method_span(
     client: Client,
     span_exporter: InMemorySpanExporter,

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -6,11 +6,12 @@ from opentelemetry.trace import StatusCode
 
 from replit_river.client import Client
 from replit_river.error_schema import RiverError
-from tests.conftest import deserialize_error, deserialize_response, serialize_request
+from tests.conftest import common_handlers, deserialize_error, deserialize_response, serialize_request
 from tests.river_fixtures.logging import NoErrors
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_rpc_method_span(
     client: Client, span_exporter: InMemorySpanExporter
 ) -> None:
@@ -29,6 +30,7 @@ async def test_rpc_method_span(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_upload_method_span(
     client: Client, span_exporter: InMemorySpanExporter
 ) -> None:
@@ -54,6 +56,7 @@ async def test_upload_method_span(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_subscription_method_span(
     client: Client, span_exporter: InMemorySpanExporter
 ) -> None:
@@ -74,6 +77,7 @@ async def test_subscription_method_span(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_stream_method_span(
     client: Client, span_exporter: InMemorySpanExporter
 ) -> None:
@@ -108,6 +112,7 @@ async def test_stream_method_span(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [common_handlers])
 async def test_stream_error_method_span(
     client: Client,
     span_exporter: InMemorySpanExporter,

--- a/uv.lock
+++ b/uv.lock
@@ -597,6 +597,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "types-nanoid" },
     { name = "types-protobuf" },
 ]
 
@@ -627,6 +628,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.11.1" },
     { name = "ruff", specifier = ">=0.0.278" },
+    { name = "types-nanoid", specifier = ">=2.0.0.20240601" },
     { name = "types-protobuf", specifier = ">=4.24.0.20240311" },
 ]
 
@@ -671,6 +673,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237 },
+]
+
+[[package]]
+name = "types-nanoid"
+version = "2.0.0.20240601"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/f2/b42b17bf27e90aa8dd9a06721b35804842ca72afac294b700b4fa23ffc92/types-nanoid-2.0.0.20240601.tar.gz", hash = "sha256:7246ee685ed55a367fc160d87cde75a550296ecca26e0602619552dae72efda0", size = 2614 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/2c/a584a285447ecb1997cda73477550068f461885e1676a4ac271ad16f8078/types_nanoid-2.0.0.20240601-py3-none-any.whl", hash = "sha256:5219f721b80748d82b14edd5429cc888d32eb816966d2a4719730ef3f2e3a417", size = 3862 },
 ]
 
 [[package]]


### PR DESCRIPTION
Why
===

Striking a balance between test handler reuse and colocating the handler specifiers with the tests that use them.

What changed
============

- Decomposing monolithic server handler specifiers into directly DI-ing reusable components
- For tests that need bespoke handlers, defining those alongside the methods that use them.

Test plan
=========

CI