### PR TITLE
Resolve pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev-dependencies = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.1",
     "pytest-cov>=4.1.0",
+    "pytest-env>=1.1.5",
     "pytest-mock>=3.11.1",
     "ruff>=0.0.278",
     "types-protobuf>=4.24.0.20240311",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
-import asyncio
-import logging
-from typing import Any, AsyncGenerator, Literal, Mapping
+from typing import Any, Mapping
 
 import nanoid
 import pytest
@@ -8,21 +6,15 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from websockets.server import serve
 
-from replit_river.client import Client
-from replit_river.client_transport import UriAndMetadata
 from replit_river.error_schema import RiverError
 from replit_river.rpc import (
     GenericRpcHandler,
     TransportMessage,
 )
-from replit_river.server import Server
-from replit_river.transport_options import TransportOptions
-from tests.river_fixtures.logging import NoErrors
 
 # Modular fixtures
-pytest_plugins = ["tests.river_fixtures.logging"]
+pytest_plugins = ["tests.river_fixtures.logging", "tests.river_fixtures.clientserver"]
 
 HandlerMapping = Mapping[tuple[str, str], tuple[str, GenericRpcHandler]]
 
@@ -66,58 +58,6 @@ def deserialize_response(response: dict) -> str:
 
 def deserialize_error(response: dict) -> RiverError:
     return RiverError.model_validate(response)
-
-
-@pytest.fixture
-def transport_options() -> TransportOptions:
-    return TransportOptions()
-
-
-@pytest.fixture
-def server_handlers(handlers: HandlerMapping) -> HandlerMapping:
-    return handlers
-
-
-@pytest.fixture
-def server(
-    transport_options: TransportOptions, server_handlers: HandlerMapping
-) -> Server:
-    server = Server(server_id="test_server", transport_options=transport_options)
-    server.add_rpc_handlers(server_handlers)
-    return server
-
-
-@pytest.fixture
-async def client(
-    server: Server,
-    transport_options: TransportOptions,
-    no_logging_error: NoErrors,
-) -> AsyncGenerator[Client, None]:
-    async def websocket_uri_factory() -> UriAndMetadata[None]:
-        return {
-            "uri": "ws://localhost:8765",
-            "metadata": None,
-        }
-
-    try:
-        async with serve(server.serve, "localhost", 8765):
-            client: Client[Literal[None]] = Client[None](
-                uri_and_metadata_factory=websocket_uri_factory,
-                client_id="test_client",
-                server_id="test_server",
-                transport_options=transport_options,
-            )
-            try:
-                yield client
-            finally:
-                logging.debug("Start closing test client : %s", "test_client")
-                await client.close()
-    finally:
-        await asyncio.sleep(1)
-        logging.debug("Start closing test server")
-        await server.close()
-        # Server should close normally
-        no_logging_error()
 
 
 @pytest.fixture(scope="session")

--- a/tests/river_fixtures/clientserver.py
+++ b/tests/river_fixtures/clientserver.py
@@ -1,0 +1,65 @@
+import asyncio
+import logging
+from typing import AsyncGenerator, Literal
+
+import pytest
+from websockets.server import serve
+
+from replit_river.client import Client
+from replit_river.client_transport import UriAndMetadata
+from replit_river.server import Server
+from replit_river.transport_options import TransportOptions
+from tests.conftest import HandlerMapping
+from tests.river_fixtures.logging import NoErrors  # noqa: E402
+
+
+@pytest.fixture
+def transport_options() -> TransportOptions:
+    return TransportOptions()
+
+
+@pytest.fixture
+def server_handlers(handlers: HandlerMapping) -> HandlerMapping:
+    return handlers
+
+
+@pytest.fixture
+def server(
+    transport_options: TransportOptions, server_handlers: HandlerMapping
+) -> Server:
+    server = Server(server_id="test_server", transport_options=transport_options)
+    server.add_rpc_handlers(server_handlers)
+    return server
+
+
+@pytest.fixture
+async def client(
+    server: Server,
+    transport_options: TransportOptions,
+    no_logging_error: NoErrors,
+) -> AsyncGenerator[Client, None]:
+    async def websocket_uri_factory() -> UriAndMetadata[None]:
+        return {
+            "uri": "ws://localhost:8765",
+            "metadata": None,
+        }
+
+    try:
+        async with serve(server.serve, "localhost", 8765):
+            client: Client[Literal[None]] = Client[None](
+                uri_and_metadata_factory=websocket_uri_factory,
+                client_id="test_client",
+                server_id="test_server",
+                transport_options=transport_options,
+            )
+            try:
+                yield client
+            finally:
+                logging.debug("Start closing test client : %s", "test_client")
+                await client.close()
+    finally:
+        await asyncio.sleep(1)
+        logging.debug("Start closing test server")
+        await server.close()
+        # Server should close normally
+        no_logging_error()

--- a/uv.lock
+++ b/uv.lock
@@ -556,6 +556,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-env"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/31/27f28431a16b83cab7a636dce59cf397517807d247caa38ee67d65e71ef8/pytest_env-1.1.5.tar.gz", hash = "sha256:91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf", size = 8911 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/b8/87cfb16045c9d4092cfcf526135d73b88101aac83bc1adcf82dfb5fd3833/pytest_env-1.1.5-py3-none-any.whl", hash = "sha256:ce90cf8772878515c24b31cd97c7fa1f4481cd68d588419fd45f10ecaee6bc30", size = 6141 },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -595,6 +607,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-env" },
     { name = "pytest-mock" },
     { name = "ruff" },
     { name = "types-nanoid" },
@@ -626,6 +639,7 @@ dev = [
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.1" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-mock", specifier = ">=3.11.1" },
     { name = "ruff", specifier = ">=0.0.278" },
     { name = "types-nanoid", specifier = ">=2.0.0.20240601" },


### PR DESCRIPTION
Why
===

Running `pytest` reports two warnings, it should not.

What changed
============

- `client` depends on `NoError`, but since by the time pytest is initialized the package has already been imported, pytest raises a warning. Move `client` (and `server`, for completeness,) out into a plugin.
- `tool.pytest.ini_options.env` isn't recognized without `pytest-env`

Test plan
=========

CI