### PR TITLE
Address incorrect packaging information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,7 @@ module = [
 	"nanoid.*",
 ]
 ignore_missing_imports = true
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 [[package]]
 name = "replit-river"
 version = "0.0.0a0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "aiochannel" },
     { name = "grpcio" },


### PR DESCRIPTION
Why
===

Looks like setuptools has some issues with a new pypi restriction: https://github.com/astral-sh/uv/issues/9513. Hatchling does not have these issues.

What changed
============

Switch to hatchling

Test plan
=========

Can we publish?