### PR TITLE
[bug] Forgot type render call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ dependencies = [
     "opentelemetry-api>=1.28.2",
 ]
 
+[project.scripts]
+lint = "lint:main"
+format = "lint:main"
+
 [tool.uv]
 dev-dependencies = [
     "deptry>=0.14.0",

--- a/src/lint.py
+++ b/src/lint.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+
+def raise_err(code: int) -> None:
+    if code > 0:
+        sys.exit(1)
+
+
+def main() -> None:
+    fix = ["--fix"] if "--fix" in sys.argv else []
+    raise_err(os.system(" ".join(["ruff", "check", "src"] + fix)))
+    raise_err(os.system("ruff format src"))
+    raise_err(os.system("mypy src"))
+    raise_err(os.system("pyright src"))

--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -959,7 +959,7 @@ def generate_individual_service(
               self,
               init: {init_type},
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
-            ) -> {output_type}:
+            ) -> {render_type_expr(output_type)}:
               return await self.client.send_upload(
                 {repr(schema_name)},
                 {repr(name)},

--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -957,7 +957,7 @@ def generate_individual_service(
                             f"""\
             async def {name}(
               self,
-              init: {init_type},
+              init: {render_type_expr(init_type)},
               inputStream: AsyncIterable[{render_type_expr(input_type)}],
             ) -> {render_type_expr(output_type)}:
               return await self.client.send_upload(

--- a/src/replit_river/codegen/typing.py
+++ b/src/replit_river/codegen/typing.py
@@ -1,13 +1,20 @@
 from dataclasses import dataclass
 from typing import NewType, assert_never
 
-TypeName = NewType("TypeName", str)
 ModuleName = NewType("ModuleName", str)
 ClassName = NewType("ClassName", str)
 FileContents = NewType("FileContents", str)
 HandshakeType = NewType("HandshakeType", str)
 
 RenderedPath = NewType("RenderedPath", str)
+
+
+@dataclass(frozen=True)
+class TypeName:
+    value: str
+
+    def __str__(self) -> str:
+        raise Exception("Complex type must be put through render_type_expr!")
 
 
 @dataclass(frozen=True)
@@ -77,10 +84,14 @@ def render_type_expr(value: TypeExpression) -> str:
                 "WrapValidator(translate_unknown_value)"
                 "]"
             )
-        case str(name):
-            return TypeName(name)
+        case TypeName(name):
+            return name
         case other:
             assert_never(other)
+
+
+def render_literal_type(value: TypeExpression) -> str:
+    return render_type_expr(ensure_literal_type(value))
 
 
 def extract_inner_type(value: TypeExpression) -> TypeName:
@@ -99,7 +110,7 @@ def extract_inner_type(value: TypeExpression) -> TypeName:
             raise ValueError(
                 f"Attempting to extract from a union, currently not possible: {value}"
             )
-        case str(name):
+        case TypeName(name):
             return TypeName(name)
         case other:
             assert_never(other)
@@ -127,7 +138,7 @@ def ensure_literal_type(value: TypeExpression) -> TypeName:
             raise ValueError(
                 f"Unexpected expression when expecting a type name: {value}"
             )
-        case str(name):
+        case TypeName(name):
             return TypeName(name)
         case other:
             assert_never(other)

--- a/src/replit_river/codegen/typing.py
+++ b/src/replit_river/codegen/typing.py
@@ -14,25 +14,40 @@ RenderedPath = NewType("RenderedPath", str)
 class DictTypeExpr:
     nested: "TypeExpression"
 
+    def __str__(self) -> str:
+        raise Exception("Complex type must be put through render_type_expr!")
+
 
 @dataclass
 class ListTypeExpr:
     nested: "TypeExpression"
+
+    def __str__(self) -> str:
+        raise Exception("Complex type must be put through render_type_expr!")
 
 
 @dataclass
 class LiteralTypeExpr:
     nested: int | str
 
+    def __str__(self) -> str:
+        raise Exception("Complex type must be put through render_type_expr!")
+
 
 @dataclass
 class UnionTypeExpr:
     nested: list["TypeExpression"]
 
+    def __str__(self) -> str:
+        raise Exception("Complex type must be put through render_type_expr!")
+
 
 @dataclass
 class OpenUnionTypeExpr:
     union: UnionTypeExpr
+
+    def __str__(self) -> str:
+        raise Exception("Complex type must be put through render_type_expr!")
 
 
 TypeExpression = (

--- a/src/replit_river/codegen/typing.py
+++ b/src/replit_river/codegen/typing.py
@@ -10,7 +10,7 @@ HandshakeType = NewType("HandshakeType", str)
 RenderedPath = NewType("RenderedPath", str)
 
 
-@dataclass
+@dataclass(frozen=True)
 class DictTypeExpr:
     nested: "TypeExpression"
 
@@ -18,7 +18,7 @@ class DictTypeExpr:
         raise Exception("Complex type must be put through render_type_expr!")
 
 
-@dataclass
+@dataclass(frozen=True)
 class ListTypeExpr:
     nested: "TypeExpression"
 
@@ -26,7 +26,7 @@ class ListTypeExpr:
         raise Exception("Complex type must be put through render_type_expr!")
 
 
-@dataclass
+@dataclass(frozen=True)
 class LiteralTypeExpr:
     nested: int | str
 
@@ -34,7 +34,7 @@ class LiteralTypeExpr:
         raise Exception("Complex type must be put through render_type_expr!")
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnionTypeExpr:
     nested: list["TypeExpression"]
 
@@ -42,7 +42,7 @@ class UnionTypeExpr:
         raise Exception("Complex type must be put through render_type_expr!")
 
 
-@dataclass
+@dataclass(frozen=True)
 class OpenUnionTypeExpr:
     union: UnionTypeExpr
 


### PR DESCRIPTION
Why
===

Ended up leaking a raw `TypeExpression` into generated code by forgetting this render call.

Also made the rest of these dataclasses throw when used incorrectly.

What changed
============

- Fixed the bug
- Made it impossible to happen again

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
