### PR TITLE
[bug] Remove the linter from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,6 @@ dependencies = [
     "opentelemetry-api>=1.28.2",
 ]
 
-[project.scripts]
-lint = "lint:main"
-format = "lint:main"
-
 [tool.uv]
 dev-dependencies = [
     "deptry>=0.14.0",


### PR DESCRIPTION
Why
===

For unknown reasons, this appearing in this package breaks other packages that depend on a script called `lint`.

What changed
============

This change temporarily reverts that so that other packages don't break.

Test plan
=========

Publish package, `uv run lint` in other packages call _their_ implementation instead of ours.