### PR TITLE
Switch from context manager to a straight binding to avoid deadlock

### DIFF
--- a/tests/river_fixtures/clientserver.py
+++ b/tests/river_fixtures/clientserver.py
@@ -38,32 +38,38 @@ async def client(
     transport_options: TransportOptions,
     no_logging_error: NoErrors,
 ) -> AsyncGenerator[Client, None]:
+    binding = None
     try:
-        async with serve(server.serve, "127.0.0.1") as binding:
-            sockets = list(binding.sockets)
-            assert len(sockets) == 1, "Too many sockets!"
-            socket = sockets[0]
+        binding = await serve(server.serve, "127.0.0.1")
+        sockets = list(binding.sockets)
+        assert len(sockets) == 1, "Too many sockets!"
+        socket = sockets[0]
 
-            async def websocket_uri_factory() -> UriAndMetadata[None]:
-                return {
-                    "uri": "ws://%s:%d" % socket.getsockname(),
-                    "metadata": None,
-                }
+        async def websocket_uri_factory() -> UriAndMetadata[None]:
+            return {
+                "uri": "ws://%s:%d" % socket.getsockname(),
+                "metadata": None,
+            }
 
-            client: Client[Literal[None]] = Client[None](
-                uri_and_metadata_factory=websocket_uri_factory,
-                client_id="test_client",
-                server_id="test_server",
-                transport_options=transport_options,
-            )
-            try:
-                yield client
-            finally:
-                logging.debug("Start closing test client : %s", "test_client")
-                await client.close()
+        client: Client[Literal[None]] = Client[None](
+            uri_and_metadata_factory=websocket_uri_factory,
+            client_id="test_client",
+            server_id="test_server",
+            transport_options=transport_options,
+        )
+        try:
+            yield client
+        finally:
+            logging.debug("Start closing test client : %s", "test_client")
+            await client.close()
+
     finally:
         await asyncio.sleep(1)
         logging.debug("Start closing test server")
+        if binding:
+            binding.close()
         await server.close()
+        if binding:
+            await binding.wait_closed()
         # Server should close normally
         no_logging_error()


### PR DESCRIPTION
Why
===

Attempting to run `uv run pytest -k test_ignore_flood_subscription` hangs for a significant amount of time.

This is because in `__aexit__` we await on the server's `wait_closed()`, which never completes because we still haven't called `server.close()`:

```
    async def __aexit__(...) -> None:
        self.ws_server.close()
        await self.ws_server.wait_closed()
```

An alternate approach would be to wrap the entire innards of the async context in a `try: ... finally: server.close()`.

What changed
============

Reflowed `clientserver` text fixture to avoid a deadlock.

Test plan
=========

CI