### PR TITLE
[bug] type adapter bugfix

### DIFF
--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -1013,6 +1013,12 @@ def generate_individual_service(
                 ]
             )
         elif procedure.type == "subscription":
+            output_or_error_type = UnionTypeExpr(
+                [
+                    output_or_error_type,
+                    TypeName("RiverError"),
+                ]
+            )
             current_chunks.extend(
                 [
                     reindent(
@@ -1086,7 +1092,12 @@ def generate_individual_service(
                     ]
                 )
         elif procedure.type == "stream":
-            output_or_error_type = UnionTypeExpr([output_or_error_type, TypeName("RiverError")])
+            output_or_error_type = UnionTypeExpr(
+                [
+                    output_or_error_type,
+                    TypeName("RiverError"),
+                ]
+            )
             if init_type:
                 assert render_init_method, "Expected an init renderer!"
                 current_chunks.extend(

--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -1086,6 +1086,7 @@ def generate_individual_service(
                     ]
                 )
         elif procedure.type == "stream":
+            output_or_error_type = UnionTypeExpr([output_or_error_type, TypeName("RiverError")])
             if init_type:
                 assert render_init_method, "Expected an init renderer!"
                 current_chunks.extend(


### PR DESCRIPTION
Why
===

We missed a few places where we don't include `RiverError` in the emitted events, leading to codegen not passing typechecking.

What changed
============

Patch in `| RiverError` in those cases where it is mandatory so at least we won't forget it.

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
