### PR TITLE
patch reconnect deadlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ lint:
 format:
 	uv run ruff format src tests
 	uv run ruff check src tests --fix
+
+test:
+	uv run pytest tests

--- a/src/replit_river/client_transport.py
+++ b/src/replit_river/client_transport.py
@@ -344,7 +344,6 @@ class ClientTransport(Transport, Generic[HandshakeMetadataType]):
                 # If the session status is mismatched, we should close the old session
                 # and let the retry logic to create a new session.
                 await old_session.close()
-                await self._delete_session(old_session)
 
             raise RiverException(
                 ERROR_HANDSHAKE,

--- a/src/replit_river/server_transport.py
+++ b/src/replit_river/server_transport.py
@@ -236,9 +236,7 @@ class ServerTransport(Transport):
         client_next_expected_seq = (
             handshake_request.expectedSessionState.nextExpectedSeq
         )
-        client_next_sent_seq = (
-            handshake_request.expectedSessionState.nextSentSeq or 0
-        )
+        client_next_sent_seq = handshake_request.expectedSessionState.nextSentSeq or 0
         if old_session and old_session.session_id == handshake_request.sessionId:
             # check invariants
             # ordering must be correct
@@ -274,7 +272,6 @@ class ServerTransport(Transport):
             # just delete the old session
             await old_session.close()
             old_session = None
-
 
         if not old_session and (
             client_next_sent_seq > 0 or client_next_expected_seq > 0

--- a/src/replit_river/server_transport.py
+++ b/src/replit_river/server_transport.py
@@ -270,7 +270,6 @@ class ServerTransport(Transport):
                 # we have an old session but the session id is different
                 # just delete the old session
                 await old_session.close()
-                await self._delete_session(old_session)
                 old_session = None
 
             if not old_session and (

--- a/tests/river_fixtures/clientserver.py
+++ b/tests/river_fixtures/clientserver.py
@@ -62,7 +62,6 @@ async def client(
                 logging.debug("Start closing test client : %s", "test_client")
                 await client.close()
     finally:
-        await asyncio.sleep(1)
         logging.debug("Start closing test server")
         await server.close()
         # Server should close normally

--- a/tests/river_fixtures/clientserver.py
+++ b/tests/river_fixtures/clientserver.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import AsyncGenerator, Literal
 

--- a/tests/river_fixtures/clientserver.py
+++ b/tests/river_fixtures/clientserver.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import AsyncGenerator, Literal
 
@@ -38,37 +37,31 @@ async def client(
     transport_options: TransportOptions,
     no_logging_error: NoErrors,
 ) -> AsyncGenerator[Client, None]:
-    binding = None
     try:
-        binding = await serve(server.serve, "127.0.0.1")
-        sockets = list(binding.sockets)
-        assert len(sockets) == 1, "Too many sockets!"
-        socket = sockets[0]
+        async with serve(server.serve, "127.0.0.1") as binding:
+            sockets = list(binding.sockets)
+            assert len(sockets) == 1, "Too many sockets!"
+            socket = sockets[0]
 
-        async def websocket_uri_factory() -> UriAndMetadata[None]:
-            return {
-                "uri": "ws://%s:%d" % socket.getsockname(),
-                "metadata": None,
-            }
+            async def websocket_uri_factory() -> UriAndMetadata[None]:
+                return {
+                    "uri": "ws://%s:%d" % socket.getsockname(),
+                    "metadata": None,
+                }
 
-        client: Client[Literal[None]] = Client[None](
-            uri_and_metadata_factory=websocket_uri_factory,
-            client_id="test_client",
-            server_id="test_server",
-            transport_options=transport_options,
-        )
-        try:
-            yield client
-        finally:
-            logging.debug("Start closing test client : %s", "test_client")
-            await client.close()
-
+            client: Client[Literal[None]] = Client[None](
+                uri_and_metadata_factory=websocket_uri_factory,
+                client_id="test_client",
+                server_id="test_server",
+                transport_options=transport_options,
+            )
+            try:
+                yield client
+            finally:
+                logging.debug("Start closing test client : %s", "test_client")
+                await client.close()
     finally:
         logging.debug("Start closing test server")
-        if binding:
-            binding.close()
         await server.close()
-        if binding:
-            await binding.wait_closed()
         # Server should close normally
         no_logging_error()

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -268,3 +268,30 @@ async def test_ignore_flood_subscription(client: Client) -> None:
         timedelta(seconds=20),
     )
     assert response == "Hello, Alice!"
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handlers", [{**basic_rpc_method}])
+async def test_rpc_method_reconnect(client: Client) -> None:
+    response = await client.send_rpc(
+        "test_service",
+        "rpc_method",
+        "Alice",
+        serialize_request,
+        deserialize_response,
+        deserialize_error,
+        timedelta(seconds=20),
+    )
+    assert response == "Hello, Alice!"
+
+    await client._transport._close_all_sessions()
+    response = await client.send_rpc(
+        "test_service",
+        "rpc_method",
+        "Bob",
+        serialize_request,
+        deserialize_response,
+        deserialize_error,
+        timedelta(seconds=20),
+    )
+
+    assert response == "Hello, Bob!"

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -269,6 +269,7 @@ async def test_ignore_flood_subscription(client: Client) -> None:
     )
     assert response == "Hello, Alice!"
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("handlers", [{**basic_rpc_method}])
 async def test_rpc_method_reconnect(client: Client) -> None:


### PR DESCRIPTION
Why
===

deadlock in the server-side reconnect case:
1. establish handshake acquires session lock: https://github.com/replit/river-python/blob/main/src/replit_river/server_transport.py#L231
2. if there is a session mismatch, we close the old session: https://github.com/replit/river-python/blob/main/src/replit_river/server_transport.py#L272
3. session.close calls _close_session_callback https://github.com/replit/river-python/blob/main/src/replit_river/session.py#L562 which is bound to transport._delete_session
4. _delete_session also tries to acquire the session lock https://github.com/replit/river-python/blob/main/src/replit_river/transport.py#L44

What changed
============

split up critical sections in server transport similar to client side
1. make `_get_session` acquire lock, dont need to lock for creating the session until we call `_set_session`
2. close session also acquires its own lock

Test plan
=========

added a test

Notes
=========

I have a draft of a more in-depth approach on [this branch](https://github.com/replit/river-python/tree/jackyzha0/fix-deadlock) which uses a lock-ownership-transfer based approach that should catch it more generically but ran into ownership problems lol

Seeing as we are planning on migrating chat service to Node anyways so we only have one River server implementation, we hopefully don't have to maintain this surface for much longer 🤞 