### PR TITLE
[chore] Remove type:ignore for field renames

### DIFF
--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -646,42 +646,24 @@ def encode_type(
                         case LiteralTypeExpr(literal_value):
                             field_value = repr(literal_value)
                     if name not in type.required:
+                        type_name = UnionTypeExpr(
+                            [
+                                type_name,
+                                NoneTypeExpr(),
+                            ]
+                        )
                         value = ""
                         if base_model != "TypedDict":
-                            value = dedent(
-                                f"""\
-                                = Field(
-                                  default=None,
-                                  alias={repr(name)}, # type: ignore
-                                )
-                                """
-                            )
-                        current_chunks.append(
-                            f"  kind: {
-                                render_type_expr(
-                                    UnionTypeExpr(
-                                        [
-                                            type_name,
-                                            NoneTypeExpr(),
-                                        ]
-                                    )
-                                )
-                            }{value}"
-                        )
+                            value = f"= {repr(None)}"
                     else:
                         value = ""
                         if base_model != "TypedDict":
-                            value = dedent(
-                                f"""\
-                                = Field(
-                                    {field_value},
-                                    alias={repr(name)}, # type: ignore
-                                )
-                                """
-                            )
-                        current_chunks.append(
-                            f"  kind: {render_type_expr(type_name)}{value}"
-                        )
+                            value = f"= {field_value}"
+                    current_chunks.append(
+                        f"  kind: Annotated[{render_type_expr(type_name)}, Field(alias={
+                            repr(name)
+                        })]{value}"
+                    )
                 else:
                     if name not in type.required:
                         if base_model == "TypedDict":

--- a/tests/codegen/snapshot/snapshots/test_unknown_enum/enumService/needsEnumObject.py
+++ b/tests/codegen/snapshot/snapshots/test_unknown_enum/enumService/needsEnumObject.py
@@ -38,7 +38,7 @@ def encode_NeedsenumobjectInputOneOf_in_first(
 
 
 class NeedsenumobjectInputOneOf_in_first(TypedDict):
-    kind: Literal["in_first"]
+    kind: Annotated[Literal["in_first"], Field(alias="$kind")]
     value: str
 
 
@@ -58,7 +58,7 @@ def encode_NeedsenumobjectInputOneOf_in_second(
 
 
 class NeedsenumobjectInputOneOf_in_second(TypedDict):
-    kind: Literal["in_second"]
+    kind: Annotated[Literal["in_second"], Field(alias="$kind")]
     bleep: int
 
 
@@ -83,20 +83,12 @@ NeedsenumobjectInputTypeAdapter: TypeAdapter[NeedsenumobjectInput] = TypeAdapter
 
 
 class NeedsenumobjectOutputFooOneOf_out_first(BaseModel):
-    kind: Literal["out_first"] = Field(
-        "out_first",
-        alias="$kind",  # type: ignore
-    )
-
+    kind: Annotated[Literal["out_first"], Field(alias="$kind")] = "out_first"
     foo: int
 
 
 class NeedsenumobjectOutputFooOneOf_out_second(BaseModel):
-    kind: Literal["out_second"] = Field(
-        "out_second",
-        alias="$kind",  # type: ignore
-    )
-
+    kind: Annotated[Literal["out_second"], Field(alias="$kind")] = "out_second"
     bar: int
 
 


### PR DESCRIPTION
Why
===

We had one overly-broad `# type: ignore` due to using the old-style of pydantic field renaming. Switching to PEP593-`Annotated` types, we can communicate the alias as well as the default value correctly.

What changed
============

Simplified codegen
Added tests

Test plan
=========

CI