### PR TITLE
[codegen] Allow optional arrays

### DIFF
--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -631,6 +631,16 @@ def encode_type(
                                             """.rstrip()
                                             )
                                         )
+                                        if name not in prop.required:
+                                            typeddict_encoder.append(
+                                                dedent(
+                                                    f"""
+                                                    if {repr(name)} in x
+                                                    and x[{repr(name)}] is not None
+                                                    else None
+                                                """
+                                                )
+                                            )
                         else:
                             if name in prop.required:
                                 typeddict_encoder.append(f"x[{repr(safe_name)}]")


### PR DESCRIPTION
Why
===

We have optional arrays, and it would be real neat if we could codegen them.

What changed
============

This change codegens them.

Test plan
=========

https://github.com/replit/ai-infra/actions/runs/14393070588/job/40363959208 doesn't fail again.