### PR TITLE
[bug] Address proactive reconnect codepaths

### DIFF
--- a/src/replit_river/rate_limiter.py
+++ b/src/replit_river/rate_limiter.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import random
 from contextvars import Context
+from typing import Protocol
 
 from replit_river.error_schema import RiverException
 from replit_river.transport_options import ConnectionRetryOptions
@@ -13,6 +14,13 @@ class BudgetExhaustedException(RiverException):
     def __init__(self, code: str, message: str, client_id: str) -> None:
         super().__init__(code, message)
         self.client_id = client_id
+
+
+class RateLimiter(Protocol):
+    def start_restoring_budget(self, user: str) -> None: ...
+    def get_backoff_ms(self, user: str) -> float: ...
+    def has_budget(self, user: str) -> bool: ...
+    def consume_budget(self, user: str) -> None: ...
 
 
 class LeakyBucketRateLimit:

--- a/src/replit_river/v2/client_transport.py
+++ b/src/replit_river/v2/client_transport.py
@@ -80,7 +80,7 @@ class ClientTransport(Generic[HandshakeMetadataType]):
         logger.debug("Triggering get_or_create_session")
         return await self.get_or_create_session()
 
-    async def _delete_session(self, session: Session) -> None:
+    def _delete_session(self, session: Session) -> None:
         if self._session is session:
             self._session = None
         else:

--- a/src/replit_river/v2/client_transport.py
+++ b/src/replit_river/v2/client_transport.py
@@ -54,8 +54,10 @@ class ClientTransport(Generic[HandshakeMetadataType]):
         call ensure_connected on whatever session is active.
         """
         existing_session = self._session
-        if not existing_session or existing_session.is_closed():
+        if not existing_session or existing_session.is_terminal():
             logger.info("Creating new session")
+            if existing_session:
+                await existing_session.close()
             new_session = Session(
                 client_id=self._client_id,
                 server_id=self._server_id,

--- a/src/replit_river/v2/session.py
+++ b/src/replit_river/v2/session.py
@@ -1274,6 +1274,9 @@ async def _recv_from_ws(
                 # is no @overrides in `websockets` to hint this.
                 try:
                     message = await ws.recv(decode=False)
+                except ConnectionClosedOK as e:
+                    close_session(e)
+                    continue
                 except ConnectionClosed:
                     # This triggers a break in the inner loop so we can get back to
                     # the outer loop.

--- a/src/replit_river/v2/session.py
+++ b/src/replit_river/v2/session.py
@@ -26,6 +26,7 @@ from aiochannel.errors import ChannelClosed
 from opentelemetry.trace import Span, use_span
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import ValidationError
+from websockets import ConnectionClosedOK
 from websockets.asyncio.client import ClientConnection
 from websockets.exceptions import ConnectionClosed
 
@@ -1119,6 +1120,9 @@ async def _do_ensure_connected[HandshakeMetadata](
 
             try:
                 data = await ws.recv(decode=False)
+            except ConnectionClosedOK as e:
+                close_session(e)
+                continue
             except ConnectionClosed as e:
                 logger.debug(
                     "_do_ensure_connected: Connection closed during waiting "

--- a/src/replit_river/v2/session.py
+++ b/src/replit_river/v2/session.py
@@ -54,7 +54,7 @@ from replit_river.messages import (
     parse_transport_msg,
     send_transport_message,
 )
-from replit_river.rate_limiter import LeakyBucketRateLimit
+from replit_river.rate_limiter import RateLimiter
 from replit_river.rpc import (
     ACK_BIT,
     STREAM_OPEN_BIT,
@@ -143,7 +143,7 @@ class Session[HandshakeMetadata]:
     _wait_for_connected: asyncio.Event
 
     _client_id: str
-    _rate_limiter: LeakyBucketRateLimit
+    _rate_limiter: RateLimiter
     _uri_and_metadata_factory: Callable[
         [], Awaitable[UriAndMetadata[HandshakeMetadata]]
     ]
@@ -176,7 +176,7 @@ class Session[HandshakeMetadata]:
         transport_options: TransportOptions,
         close_session_callback: CloseSessionCallback,
         client_id: str,
-        rate_limiter: LeakyBucketRateLimit,
+        rate_limiter: RateLimiter,
         uri_and_metadata_factory: Callable[
             [], Awaitable[UriAndMetadata[HandshakeMetadata]]
         ],
@@ -1034,7 +1034,7 @@ async def _do_ensure_connected[HandshakeMetadata](
     client_id: str,
     session_id: str,
     server_id: str,
-    rate_limiter: LeakyBucketRateLimit,
+    rate_limiter: RateLimiter,
     uri_and_metadata_factory: Callable[
         [], Awaitable[UriAndMetadata[HandshakeMetadata]]
     ],

--- a/src/replit_river/v2/session.py
+++ b/src/replit_river/v2/session.py
@@ -109,7 +109,7 @@ logger = logging.getLogger(__name__)
 trace_propagator = TraceContextTextMapPropagator()
 trace_setter = TransportMessageTracingSetter()
 
-CloseSessionCallback: TypeAlias = Callable[["Session"], Coroutine[Any, Any, Any]]
+CloseSessionCallback: TypeAlias = Callable[["Session"], None]
 RetryConnectionCallback: TypeAlias = Callable[
     [],
     Coroutine[Any, Any, Any],
@@ -472,7 +472,7 @@ class Session[HandshakeMetadata]:
 
         # Clear the session in transports
         # This will get us GC'd, so this should be the last thing.
-        await self._close_session_callback(self)
+        self._close_session_callback(self)
 
     def _start_buffered_message_sender(
         self,

--- a/src/replit_river/v2/session.py
+++ b/src/replit_river/v2/session.py
@@ -321,6 +321,8 @@ class Session[HandshakeMetadata]:
             )
 
         await self._connecting_task
+        if self._terminating_task:
+            await self._terminating_task
 
     def is_closed(self) -> bool:
         """

--- a/src/replit_river/v2/session.py
+++ b/src/replit_river/v2/session.py
@@ -418,8 +418,8 @@ class Session[HandshakeMetadata]:
         # ... message processor so it can exit cleanly
         self._process_messages.set()
 
-        # Wait a tick to permit the waiting tasks to shut down gracefully
-        await asyncio.sleep(0.01)
+        # Wait to permit the waiting tasks to shut down gracefully
+        await asyncio.sleep(0.25)
 
         await self._task_manager.cancel_all_tasks()
 

--- a/tests/v2/test_v2_session_lifecycle.py
+++ b/tests/v2/test_v2_session_lifecycle.py
@@ -1,0 +1,135 @@
+import asyncio
+from typing import AsyncIterator, Awaitable, Callable, TypeAlias, TypedDict
+
+import pytest
+from websockets import ConnectionClosedOK
+from websockets.asyncio.server import ServerConnection, serve
+from websockets.typing import Data
+
+from replit_river.messages import parse_transport_msg
+from replit_river.rate_limiter import RateLimiter
+from replit_river.rpc import TransportMessage
+from replit_river.transport_options import TransportOptions, UriAndMetadata
+from replit_river.v2.session import Session
+
+
+class _PermissiveRateLimiter(RateLimiter):
+    def start_restoring_budget(self, user: str) -> None:
+        pass
+
+    def get_backoff_ms(self, user: str) -> float:
+        return 0
+
+    def has_budget(self, user: str) -> bool:
+        return True
+
+    def consume_budget(self, user: str) -> None:
+        pass
+
+
+WsServerFixture: TypeAlias = tuple[
+    Callable[[], Awaitable[UriAndMetadata[None]]],
+    asyncio.Queue[bytes],
+    Callable[[], ServerConnection | None],
+]
+
+
+class _WsServerState(TypedDict):
+    ipv4_laddr: tuple[str, int] | None
+
+
+async def _ws_server_internal(
+    recv: asyncio.Queue[bytes],
+    set_conn: Callable[[ServerConnection], None],
+    state: _WsServerState,
+) -> AsyncIterator[None]:
+    async def handle(websocket: ServerConnection) -> None:
+        set_conn(websocket)
+        datagram: Data
+        try:
+            while datagram := await websocket.recv(decode=False):
+                if isinstance(datagram, str):
+                    continue
+                await recv.put(datagram)
+        except ConnectionClosedOK:
+            pass
+
+    port: int | None = None
+    if state["ipv4_laddr"]:
+        port = state["ipv4_laddr"][1]
+    async with serve(handle, "localhost", port=port) as server:
+        for sock in server.sockets:
+            if (pair := sock.getsockname())[0] == "127.0.0.1":
+                if state["ipv4_laddr"] is None:
+                    state["ipv4_laddr"] = pair
+        serve_forever = asyncio.create_task(server.serve_forever())
+        yield None
+        serve_forever.cancel()
+
+
+@pytest.fixture
+async def ws_server() -> AsyncIterator[WsServerFixture]:
+    recv: asyncio.Queue[bytes] = asyncio.Queue(maxsize=1)
+    connection: ServerConnection | None = None
+    state: _WsServerState = {"ipv4_laddr": None}
+
+    def set_conn(new_conn: ServerConnection) -> None:
+        nonlocal connection
+        connection = new_conn
+
+    server_generator = _ws_server_internal(recv, set_conn, state)
+    await anext(server_generator)
+
+    async def urimeta() -> UriAndMetadata[None]:
+        ipv4_laddr = state["ipv4_laddr"]
+        assert ipv4_laddr
+        return UriAndMetadata(uri="ws://%s:%d" % ipv4_laddr, metadata=None)
+
+    yield (urimeta, recv, lambda: connection)
+
+    try:
+        await anext(server_generator)
+    except StopAsyncIteration:
+        pass
+
+
+async def test_connect(ws_server: WsServerFixture) -> None:
+    (urimeta, recv, conn) = ws_server
+
+    session = Session(
+        server_id="SERVER",
+        session_id="SESSION1",
+        transport_options=TransportOptions(),
+        close_session_callback=lambda _: None,
+        client_id="CLIENT1",
+        rate_limiter=_PermissiveRateLimiter(),
+        uri_and_metadata_factory=urimeta,
+    )
+
+    connecting = asyncio.create_task(session.ensure_connected())
+    msg = parse_transport_msg(await recv.get())
+    assert isinstance(msg, TransportMessage)
+    assert msg.payload["type"] == "HANDSHAKE_REQ"
+    await session.close()
+    await connecting
+
+
+async def test_reconnect(ws_server: WsServerFixture) -> None:
+    (urimeta, recv, conn) = ws_server
+
+    session = Session(
+        server_id="SERVER",
+        session_id="SESSION1",
+        transport_options=TransportOptions(),
+        close_session_callback=lambda _: None,
+        client_id="CLIENT1",
+        rate_limiter=_PermissiveRateLimiter(),
+        uri_and_metadata_factory=urimeta,
+    )
+
+    connecting = asyncio.create_task(session.ensure_connected())
+    msg = parse_transport_msg(await recv.get())
+    assert isinstance(msg, TransportMessage)
+    assert msg.payload["type"] == "HANDSHAKE_REQ"
+    await session.close()
+    await connecting


### PR DESCRIPTION
Why
===

We're seeing some connectivity issues using the river v2 client. Scrutinizing codepaths, there were some missed cases

What changed
============

- `_recv_from_ws` should catch all exceptions inside the loop instead of terminating early and never restarting
- Differentiate between `ConnectionClosedOK` and `ConnectionClosed` in exception handlers. If we close on purpose, don't initiate reconnect
- `session.close()` should block all callers until we are down, instead of just the initiating caller.

Test plan
=========

CI/CD