### PR TITLE
The project expects uv to place a venv in .venv, use it

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,1 @@
+{ "venvPath": ".", "venv": ".venv" }


### PR DESCRIPTION
Why
===

Make it easier for LSPs to pick up uv's project structure

What changed
============

Add `pyrightconfig.json` to point at `.venv`

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
