### PR TITLE
[v2 bug] Disable websocket max_size

### DIFF
--- a/src/replit_river/client_transport.py
+++ b/src/replit_river/client_transport.py
@@ -170,7 +170,7 @@ class ClientTransport(Generic[HandshakeMetadataType]):
 
             try:
                 uri_and_metadata = await self._uri_and_metadata_factory()
-                ws = await websockets.connect(uri_and_metadata["uri"])
+                ws = await websockets.connect(uri_and_metadata["uri"], max_size=None)
                 session_id = (
                     self.generate_nanoid()
                     if not old_session

--- a/src/replit_river/v2/session.py
+++ b/src/replit_river/v2/session.py
@@ -1084,7 +1084,10 @@ async def _do_ensure_connected[HandshakeMetadata](
         ws: ClientConnection | None = None
         try:
             uri_and_metadata = await uri_and_metadata_factory()
-            ws = await websockets.asyncio.client.connect(uri_and_metadata["uri"])
+            ws = await websockets.asyncio.client.connect(
+                uri_and_metadata["uri"],
+                max_size=None,
+            )
             transition_connecting(ws)
 
             try:


### PR DESCRIPTION
Why
===

When we hit the maximum size of a websocket packet the websocket client proactively disconnects itself. Unfortunately this can happen outside of the observed lifecycle of the owned socket, so when we attempt to reconnect we just resend the last request and see whether or not we get a valid response.

What changed
============

- Disable `max_size` during `websocket.connect(...)`

Test plan
=========

CI

Without the bugfix commit, test logs include:

```
DEBUG    replit_river.common_session:common_session.py:102 _buffered_message_sender: Sent 'jKAcLL2O3XBL4xZF1cEWv'
DEBUG    websockets.server:protocol.py:572 < BINARY 8b a2 69 64 b5 6a 4b 41 63 4c 4c 32 4f 33 58 42 ... 70 61 79 6c 6f 61 64 80 [244 bytes]
DEBUG    websockets.server:protocol.py:719 > BINARY 88 a2 69 64 b5 52 42 59 4b 6a 42 2d 63 59 37 5f ... 61 61 61 61 61 61 61 61 [1048711 bytes]
DEBUG    websockets.client:protocol.py:719 > CLOSE 1009 (message too big) over size limit (? > 1048576 bytes) [37 bytes]
DEBUG    websockets.client:protocol.py:169 = connection is CLOSING
DEBUG    websockets.server:protocol.py:572 < CLOSE 1009 (message too big) over size limit (? > 1048576 bytes) [37 bytes]
DEBUG    websockets.server:protocol.py:719 > CLOSE 1009 (message too big) over size limit (? > 1048576 bytes) [37 bytes]
DEBUG    websockets.server:protocol.py:169 = connection is CLOSING
DEBUG    websockets.server:protocol.py:731 > EOF
DEBUG    websockets.server:connection.py:890 x half-closing TCP connection
```

but now we're able to negotiate the full response and subsequently close gracefully.