### PR TITLE
Peter/river exceptions not excepting

### DIFF
--- a/src/replit_river/client_session.py
+++ b/src/replit_river/client_session.py
@@ -252,7 +252,11 @@ class ClientSession(Session):
                 except Exception as e:
                     raise RiverException("error_deserializer", str(e)) from e
                 raise exception_from_message(error.code)(
-                    error.code, error.message, service_name, procedure_name
+                    error.code,
+                    error.message,
+                    service_name,
+                    procedure_name,
+                    underlying_error=error,
                 )
             return response_deserializer(response["payload"])
         except RiverException as e:
@@ -338,7 +342,11 @@ class ClientSession(Session):
                 except Exception as e:
                     raise RiverException("error_deserializer", str(e)) from e
                 raise exception_from_message(error.code)(
-                    error.code, error.message, service_name, procedure_name
+                    error.code,
+                    error.message,
+                    service_name,
+                    procedure_name,
+                    underlying_error=error,
                 )
 
             return response_deserializer(response["payload"])

--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -514,25 +514,6 @@ def encode_type(
                 in_module,
                 permit_unknown_members=permit_unknown_members,
             )
-            # TODO(dstewart): This structure changed since we were incorrectly leaking
-            #                 ListTypeExprs into codegen. This generated code is
-            #                 probably wrong.
-            match type_name:
-                case ListTypeExpr(inner_type_name):
-                    typeddict_encoder.append(
-                        f"encode_{render_literal_type(inner_type_name)}(x)"
-                    )
-                case DictTypeExpr(_):
-                    raise ValueError(
-                        "What does it mean to try and encode a dict in this position?"
-                    )
-                case LiteralTypeExpr(const):
-                    typeddict_encoder.append(repr(const))
-                case TypeName(value):
-                    typeddict_encoder.append(f"encode_{value}(x)")
-                case other:
-                    _o1: NoneTypeExpr | OpenUnionTypeExpr | UnionTypeExpr = other
-                    raise ValueError(f"What does it mean to have {_o1} here?")
             return (DictTypeExpr(type_name), module_info, type_chunks, encoder_names)
         assert type.type == "object", type.type
 

--- a/src/replit_river/error_schema.py
+++ b/src/replit_river/error_schema.py
@@ -51,12 +51,18 @@ class RiverServiceException(RiverException):
     """Exception raised by river as a result of a fault in the service running river."""
 
     def __init__(
-        self, code: str, message: str, service: str | None, procedure: str | None
+        self,
+        code: str,
+        message: str,
+        service: str | None,
+        procedure: str | None,
+        underlying_error: RiverError | None = None,
     ) -> None:
         self.code = code
         self.message = message
         self.service = service
         self.procedure = procedure
+        self.underlying_error = underlying_error
         service = service or "N/A"
         procedure = procedure or "N/A"
         msg = (

--- a/src/replit_river/v2/session.py
+++ b/src/replit_river/v2/session.py
@@ -790,7 +790,11 @@ class Session[HandshakeMetadata]:
                 except Exception as e:
                     raise RiverException("error_deserializer", str(e)) from e
                 raise exception_from_message(error.code)(
-                    error.code, error.message, service_name, procedure_name
+                    error.code,
+                    error.message,
+                    service_name,
+                    procedure_name,
+                    underlying_error=error,
                 )
 
             return response_deserializer(result["payload"])
@@ -899,7 +903,11 @@ class Session[HandshakeMetadata]:
                 except Exception as e:
                     raise RiverException("error_deserializer", str(e)) from e
                 raise exception_from_message(error.code)(
-                    error.code, error.message, service_name, procedure_name
+                    error.code,
+                    error.message,
+                    service_name,
+                    procedure_name,
+                    underlying_error=error,
                 )
 
             return response_deserializer(result["payload"])


### PR DESCRIPTION
Why
===

We validate the errors which might have some schema like extra fields, then we toss them away like unwanted trash. This is bad. 

What changed
============

The RiverServiceException class is updated to accept and store the original deserialized RiverError object.
Client sessions now pass this underlying_error when raising service exceptions, making the full error payload accessible.

Test plan
=========

Ran ai-infra with this. The CI/CD for that will catch anything and it's also like low key just adding stuff. 
