### PR TITLE
Error codegen

### DIFF
--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -535,7 +535,7 @@ def encode_type(
                 type_name, _, contents, _ = encode_type(
                     prop,
                     TypeName(prefix.value + name.title()),
-                    base_model,
+                    "BaseModel" if base_model == "RiverError" else base_model,
                     in_module,
                     permit_unknown_members=permit_unknown_members,
                 )

--- a/tests/v1/codegen/snapshot/snapshots/test_unknown_enum/enumService/needsEnumObject.py
+++ b/tests/v1/codegen/snapshot/snapshots/test_unknown_enum/enumService/needsEnumObject.py
@@ -104,19 +104,19 @@ NeedsenumobjectOutputTypeAdapter: TypeAdapter[NeedsenumobjectOutput] = TypeAdapt
 )
 
 
-class NeedsenumobjectErrorsFooAnyOf_0(RiverError):
+class NeedsenumobjectErrorsFooAnyOf_0(BaseModel):
     beep: Literal["err_first"] | None = None
 
 
-class NeedsenumobjectErrorsFooAnyOf_1(RiverError):
+class NeedsenumobjectErrorsFooAnyOf_1(BaseModel):
     borp: Literal["err_second"] | None = None
 
 
 NeedsenumobjectErrorsFoo = Annotated[
     NeedsenumobjectErrorsFooAnyOf_0
     | NeedsenumobjectErrorsFooAnyOf_1
-    | RiverUnknownError,
-    WrapValidator(translate_unknown_error),
+    | RiverUnknownValue,
+    WrapValidator(translate_unknown_value),
 ]
 
 


### PR DESCRIPTION
# Why
The encode_type function was incorrectly propagating the RiverError base class to all nested types when generating error schemas. This meant that if an error type had nested object properties (e.g., a field containing user details or metadata), those nested objects would also inherit from RiverError instead of BaseModel. This is incorrect because only the top-level error types should inherit from RiverError - nested properties are just data structures, not errors themselves.
# What changed
Modified the encode_type function to pass "BaseModel" instead of the current base_model value when recursively processing object properties (line 538). This is done conditionally only when the current base_model is "RiverError". The fix ensures that:
Top-level error types and union members of error types continue to inherit from RiverError
Nested properties within those error types inherit from BaseModel
All other base model types ("TypedDict", "BaseModel") maintain their existing behavior unchanged