### PR TITLE
Fix codegen for fields with dashes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Any, Literal, Mapping
 
 import nanoid
@@ -55,7 +56,11 @@ def deserialize_request(request: dict) -> str:
 
 
 def serialize_response(response: str) -> dict:
-    return {"data": response}
+    return {
+        "data": response,
+        "data2": datetime.now(timezone.utc),
+        "data-3": {"data-test": "test"},
+    }
 
 
 def deserialize_response(response: dict) -> str:

--- a/tests/v1/codegen/rpc/generated/test_service/rpc_method.py
+++ b/tests/v1/codegen/rpc/generated/test_service/rpc_method.py
@@ -30,6 +30,7 @@ def encode_Rpc_MethodInput(
         for (k, v) in (
             {
                 "data": x.get("data"),
+                "data2": x.get("data2"),
             }
         ).items()
         if v is not None
@@ -38,10 +39,17 @@ def encode_Rpc_MethodInput(
 
 class Rpc_MethodInput(TypedDict):
     data: str
+    data2: datetime.datetime
+
+
+class Rpc_MethodOutputData_3(BaseModel):
+    data_test: str | None = Field(alias="data-test", default=None)
 
 
 class Rpc_MethodOutput(BaseModel):
     data: str
+    data_3: Rpc_MethodOutputData_3 = Field(alias="data-3")
+    data2: datetime.datetime
 
 
 Rpc_MethodOutputTypeAdapter: TypeAdapter[Rpc_MethodOutput] = TypeAdapter(

--- a/tests/v1/codegen/rpc/invalid-schema.json
+++ b/tests/v1/codegen/rpc/invalid-schema.json
@@ -1,0 +1,30 @@
+{
+	"services": {
+	  "test_service": {
+		"procedures": {
+		  "rpc_method": {
+			"input": {
+			  "type": "boolean"
+			},
+			"output": {
+			  "type": "object",
+			  "properties": {
+				"data:3": {
+				  "type": "Date"
+				},
+				"data-3": {
+				  "type": "boolean"
+				}
+			  },
+			  "required": ["data:3"]
+			},
+			"errors": {
+			  "not": {}
+			},
+			"type": "rpc"
+		  }
+		}
+	  }
+	}
+  }
+  

--- a/tests/v1/codegen/rpc/schema.json
+++ b/tests/v1/codegen/rpc/schema.json
@@ -8,18 +8,33 @@
             "properties": {
               "data": {
                 "type": "string"
+              },
+              "data2": {
+                "type": "Date"
               }
             },
-            "required": ["data"]
+            "required": ["data", "data2"]
           },
           "output": {
             "type": "object",
             "properties": {
               "data": {
                 "type": "string"
+              },
+              "data2": {
+                "type": "Date"
+              },
+              "data-3": {
+                "type": "object",
+                "properties": {
+                  "data-test": {
+                    "type": "string"
+                  }
+                },
+                "required": []
               }
             },
-            "required": ["data"]
+            "required": ["data", "data2", "data-3"]
           },
           "errors": {
             "not": {}

--- a/tests/v1/codegen/snapshot/snapshots/test_unknown_enum/enumService/needsEnumObject.py
+++ b/tests/v1/codegen/snapshot/snapshots/test_unknown_enum/enumService/needsEnumObject.py
@@ -96,7 +96,7 @@ NeedsenumobjectOutputFoo = Annotated[
 
 
 class NeedsenumobjectOutput(BaseModel):
-    foo: NeedsenumobjectOutputFoo | None = None
+    foo: NeedsenumobjectOutputFoo | None = Field(default=None)
 
 
 NeedsenumobjectOutputTypeAdapter: TypeAdapter[NeedsenumobjectOutput] = TypeAdapter(
@@ -105,11 +105,11 @@ NeedsenumobjectOutputTypeAdapter: TypeAdapter[NeedsenumobjectOutput] = TypeAdapt
 
 
 class NeedsenumobjectErrorsFooAnyOf_0(BaseModel):
-    beep: Literal["err_first"] | None = None
+    beep: Literal["err_first"] | None = Field(default=None)
 
 
 class NeedsenumobjectErrorsFooAnyOf_1(BaseModel):
-    borp: Literal["err_second"] | None = None
+    borp: Literal["err_second"] | None = Field(default=None)
 
 
 NeedsenumobjectErrorsFoo = Annotated[
@@ -121,7 +121,7 @@ NeedsenumobjectErrorsFoo = Annotated[
 
 
 class NeedsenumobjectErrors(RiverError):
-    foo: NeedsenumobjectErrorsFoo | None = None
+    foo: NeedsenumobjectErrorsFoo | None = Field(default=None)
 
 
 NeedsenumobjectErrorsTypeAdapter: TypeAdapter[NeedsenumobjectErrors] = TypeAdapter(

--- a/tests/v1/codegen/test_invalid_schema.py
+++ b/tests/v1/codegen/test_invalid_schema.py
@@ -1,0 +1,27 @@
+from io import StringIO
+
+import pytest
+
+from replit_river.codegen.client import schema_to_river_client_codegen
+
+
+def test_field_name_collision_error() -> None:
+    """Test that codegen raises ValueError for field name collisions."""
+
+    with pytest.raises(ValueError) as exc_info:
+        schema_to_river_client_codegen(
+            read_schema=lambda: open("tests/v1/codegen/rpc/invalid-schema.json"),
+            target_path="tests/v1/codegen/rpc/generated",
+            client_name="InvalidClient",
+            typed_dict_inputs=True,
+            file_opener=lambda _: StringIO(),
+            method_filter=None,
+            protocol_version="v1.1",
+        )
+
+    # Check that the error message matches the expected format for field name collision
+    error_message = str(exc_info.value)
+    assert "Field name collision" in error_message
+    assert "data:3" in error_message
+    assert "data-3" in error_message
+    assert "all normalize to the same effective name 'data_3'" in error_message

--- a/tests/v1/codegen/test_rpc.py
+++ b/tests/v1/codegen/test_rpc.py
@@ -2,7 +2,7 @@ import asyncio
 import importlib
 import os
 import shutil
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TextIO
 
@@ -52,6 +52,7 @@ async def test_basic_rpc(client: Client) -> None:
     res = await RpcClient(client).test_service.rpc_method(
         {
             "data": "feep",
+            "data2": datetime.now(timezone.utc),
         },
         timedelta(seconds=5),
     )
@@ -80,8 +81,6 @@ async def test_rpc_timeout(client: Client) -> None:
 
     with pytest.raises(RiverException):
         await RpcClient(client).test_service.rpc_method(
-            {
-                "data": "feep",
-            },
+            {"data": "feep", "data2": datetime.now(timezone.utc)},
             timedelta(milliseconds=200),
         )


### PR DESCRIPTION
Why
===

Some new services require `-` `.` and `:` in field names

What changed
============

When rendering a `TypeName` its value is normalized, and a new `LiteralType` dataclass was added to avoid that normalization.

Known limitation: this new normalization only works on output types.

Test plan
=========

Run codegen on a schema with a field that has a `-` in its name
