### PR TITLE
fix complex type repr

### DIFF
--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -496,8 +496,8 @@ def encode_type(
             typeddict_encoder.append("None")
             return (NoneTypeExpr(), [], [], set())
         elif type.type == "Date":
-            typeddict_encoder.append("TODO: dstewart")
-            return (LiteralType("datetime.datetime"), [], [], set())
+            typeddict_encoder.append("datetime.datetime")
+            return (LiteralTypeExpr("datetime.datetime"), [], [], set())
         elif type.type == "array" and type.items:
             type_name, module_info, type_chunks, encoder_names = encode_type(
                 type.items,

--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -405,7 +405,11 @@ def encode_type(
                                 | UnionTypeExpr
                                 | LiteralType
                             ) = other
-                            raise ValueError(f"What does it mean to have {_o2} here?")
+                            raise ValueError(
+                                f"What does it mean to have {
+                                    render_type_expr(_o2)
+                                } here?"
+                            )
         if permit_unknown_members:
             union = _make_open_union_type_expr(any_of)
         else:
@@ -497,7 +501,7 @@ def encode_type(
             return (NoneTypeExpr(), [], [], set())
         elif type.type == "Date":
             typeddict_encoder.append("datetime.datetime")
-            return (LiteralTypeExpr("datetime.datetime"), [], [], set())
+            return (LiteralType("datetime.datetime"), [], [], set())
         elif type.type == "array" and type.items:
             type_name, module_info, type_chunks, encoder_names = encode_type(
                 type.items,


### PR DESCRIPTION
Why
===

```
  File "/Users/jzhao/projects/ai-infra/.venv/lib/python3.12/site-packages/replit_river/codegen/client.py", line 408, in encode_type
    raise ValueError(f"What does it mean to have {_o2} here?")
                                                 ^^^^^
  File "/Users/jzhao/projects/ai-infra/.venv/lib/python3.12/site-packages/replit_river/codegen/typing.py", line 33, in __str__
    raise Exception("Complex type must be put through render_type_expr!")
Exception: Complex type must be put through render_type_expr!
```

What changed
============

render the error correctly

Test plan
=========

codegen doesnt crash
