### PR TITLE
Use .get() for discriminator access in generated union encoders

### DIFF
--- a/src/replit_river/codegen/client.py
+++ b/src/replit_river/codegen/client.py
@@ -342,7 +342,7 @@ def encode_type(
                         )
                     typeddict_encoder.append(
                         f"""
-                            if x[{repr(discriminator_name)}]
+                            if x.get({repr(discriminator_name)})
                             == {repr(discriminator_value)}
                             else
                         """,

--- a/tests/v1/codegen/snapshot/snapshots/test_unknown_enum/enumService/needsEnumObject.py
+++ b/tests/v1/codegen/snapshot/snapshots/test_unknown_enum/enumService/needsEnumObject.py
@@ -75,7 +75,7 @@ def encode_NeedsenumobjectInput(
         encode_NeedsenumobjectInputOneOf_in_first(
             cast("NeedsenumobjectInputOneOf_in_first", x)
         )
-        if x["kind"] == "in_first"
+        if x.get("kind") == "in_first"
         else encode_NeedsenumobjectInputOneOf_in_second(
             cast("NeedsenumobjectInputOneOf_in_second", x)
         )


### PR DESCRIPTION
Why
===

Follow-up to #175. The discriminator field in a discriminated union may be `NotRequired` in the TypedDict. Direct key access (`x["shapeType"]`) triggers pyright's `reportTypedDictNotRequiredAccess` error.

This broke the pid2 codegen CI when the scribe schema added discriminated union variants where the discriminator field is optional.

What changed
============

Use `x.get("key")` instead of `x["key"]` for discriminator checks in the generated ternary chain. This is safe because a missing key returns `None`, which won't match any discriminator value and falls through to the next branch.

Test plan
=========

- All 64 tests pass
- Updated snapshot for `test_unknown_enum`
- Tested end-to-end against the pid2 schema from ai-infra — codegen, mypy, and pyright all pass

~ written by Zerg 👾