### PR TITLE
Fix codegen with `from` keyword

### DIFF
--- a/src/replit_river/codegen/typing.py
+++ b/src/replit_river/codegen/typing.py
@@ -1,3 +1,4 @@
+import keyword
 from dataclasses import dataclass
 from typing import NewType, assert_never, cast
 
@@ -165,7 +166,11 @@ def _flatten_nested_unions(value: TypeExpression) -> TypeExpression:
 def normalize_special_chars(value: str) -> str:
     for char in SPECIAL_CHARS:
         value = value.replace(char, "_")
-    return value.lstrip("_")
+    value = value.lstrip("_")
+    # Append underscore to Python keywords (e.g., "from" -> "from_")
+    if keyword.iskeyword(value):
+        value = value + "_"
+    return value
 
 
 def render_type_expr(value: TypeExpression) -> str:

--- a/tests/v1/codegen/test_input_special_chars.py
+++ b/tests/v1/codegen/test_input_special_chars.py
@@ -166,6 +166,11 @@ def test_init_special_chars_typeddict() -> None:
     )
 
 
+class UnclosableStringIO(StringIO):
+    def close(self) -> None:
+        pass
+
+
 def test_python_keyword_field_names_basemodel() -> None:
     """Handles Python reserved keywords as field names for BaseModel."""
 
@@ -204,10 +209,10 @@ def test_python_keyword_field_names_basemodel() -> None:
         }
     }
 
-    files: dict[Path, StringIO] = {}
+    files: dict[Path, UnclosableStringIO] = {}
 
-    def file_opener(path: Path) -> StringIO:
-        buf = StringIO()
+    def file_opener(path: Path) -> UnclosableStringIO:
+        buf = UnclosableStringIO()
         files[path] = buf
         return buf
 
@@ -271,10 +276,10 @@ def test_python_keyword_field_names_typeddict() -> None:
         }
     }
 
-    files: dict[Path, StringIO] = {}
+    files: dict[Path, UnclosableStringIO] = {}
 
-    def file_opener(path: Path) -> StringIO:
-        buf = StringIO()
+    def file_opener(path: Path) -> UnclosableStringIO:
+        buf = UnclosableStringIO()
         files[path] = buf
         return buf
 

--- a/tests/v1/codegen/test_input_special_chars.py
+++ b/tests/v1/codegen/test_input_special_chars.py
@@ -164,3 +164,137 @@ def test_init_special_chars_typeddict() -> None:
         method_filter=None,
         protocol_version="v2.0",
     )
+
+
+def test_python_keyword_field_names_basemodel() -> None:
+    """Handles Python reserved keywords as field names for BaseModel."""
+
+    import ast
+    import json
+    from pathlib import Path
+
+    keyword_schema = {
+        "services": {
+            "test_service": {
+                "procedures": {
+                    "rpc_method": {
+                        "input": {
+                            "type": "object",
+                            "properties": {
+                                "from": {"type": "string"},
+                                "to": {"type": "string"},
+                                "class": {"type": "number"},
+                                "import": {"type": "boolean"},
+                            },
+                            "required": ["from", "to"],
+                        },
+                        "output": {
+                            "type": "object",
+                            "properties": {
+                                "from": {"type": "string"},
+                                "to": {"type": "string"},
+                            },
+                            "required": ["from", "to"],
+                        },
+                        "errors": {"not": {}},
+                        "type": "rpc",
+                    }
+                }
+            }
+        }
+    }
+
+    files: dict[Path, StringIO] = {}
+
+    def file_opener(path: Path) -> StringIO:
+        buf = StringIO()
+        files[path] = buf
+        return buf
+
+    schema_to_river_client_codegen(
+        read_schema=lambda: StringIO(json.dumps(keyword_schema)),
+        target_path="test_keyword_bm",
+        client_name="KeywordBMClient",
+        typed_dict_inputs=False,
+        file_opener=file_opener,
+        method_filter=None,
+        protocol_version="v1.1",
+    )
+
+    # Verify all generated files are valid Python
+    for path, buf in files.items():
+        buf.seek(0)
+        content = buf.read()
+        try:
+            ast.parse(content)
+        except SyntaxError as e:
+            raise AssertionError(
+                f"Generated file {path} has invalid syntax: {e}\n{content}"
+            )
+
+
+def test_python_keyword_field_names_typeddict() -> None:
+    """Handles Python reserved keywords as field names for TypedDict."""
+
+    import ast
+    import json
+    from pathlib import Path
+
+    keyword_schema = {
+        "services": {
+            "test_service": {
+                "procedures": {
+                    "rpc_method": {
+                        "input": {
+                            "type": "object",
+                            "properties": {
+                                "from": {"type": "string"},
+                                "to": {"type": "string"},
+                                "class": {"type": "number"},
+                                "import": {"type": "boolean"},
+                            },
+                            "required": ["from", "to"],
+                        },
+                        "output": {
+                            "type": "object",
+                            "properties": {
+                                "from": {"type": "string"},
+                                "to": {"type": "string"},
+                            },
+                            "required": ["from", "to"],
+                        },
+                        "errors": {"not": {}},
+                        "type": "rpc",
+                    }
+                }
+            }
+        }
+    }
+
+    files: dict[Path, StringIO] = {}
+
+    def file_opener(path: Path) -> StringIO:
+        buf = StringIO()
+        files[path] = buf
+        return buf
+
+    schema_to_river_client_codegen(
+        read_schema=lambda: StringIO(json.dumps(keyword_schema)),
+        target_path="test_keyword_td",
+        client_name="KeywordTDClient",
+        typed_dict_inputs=True,
+        file_opener=file_opener,
+        method_filter=None,
+        protocol_version="v1.1",
+    )
+
+    # Verify all generated files are valid Python
+    for path, buf in files.items():
+        buf.seek(0)
+        content = buf.read()
+        try:
+            ast.parse(content)
+        except SyntaxError as e:
+            raise AssertionError(
+                f"Generated file {path} has invalid syntax: {e}\n{content}"
+            )


### PR DESCRIPTION
Why
===

For schema with `from` and `to` properties. from is a Python reserved keyword, and the river-python codegen was generating invalid Python like:

```
class Rewrites(TypedDict):
    from: NotRequired[str | None]   # SyntaxError!
```


What changed
============

- src/replit_river/codegen/typing.py — Added import keyword and extended normalize_special_chars to append _ to Python keywords (e.g., from -> from_). The existing alias logic in client.py already handles setting Field(alias="from") for BaseModel when the field name is normalized, so no changes needed there.

- tests/v1/codegen/test_input_special_chars.py — Added two new tests (test_python_keyword_field_names_basemodel and test_python_keyword_field_names_typeddict) that verify the codegen produces valid Python when schema fields use reserved keywords like from, class, and import.

Test plan
=========

Added new tests
